### PR TITLE
Update broken link for contributing and add Find Duplicate SKU Task

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/dictionaries
+++ b/.idea/dictionaries
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectDictionaryState">
+    <dictionary name="Kirk" />
+  </component>
+</project>

--- a/.idea/mechanic-tasks.iml
+++ b/.idea/mechanic-tasks.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/mechanic-tasks.iml" filepath="$PROJECT_DIR$/.idea/mechanic-tasks.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ New and updated tasks are accepted via pull request. Each pull request should re
 * Task tags must come from the list in [lib/task_schema.json](./lib/task_schema.json). Feel free to add tags to that list! The maintainers will review those changes too. :)
 * Changes to the task should be represented by a new or updated task JSON export (see [Importing and exporting tasks](https://docs.usemechanic.com/article/505-importing-and-exporting-tasks)). This JSON file must be located in the [tasks/](./tasks/) directory, named with an appropriate handle for the task. (For example, a task named "Hide out-of-stock products" should have its JSON export stored in "tasks/hide-out-of-stock-products.json".)
 * After each change to the JSON export file, run `npm run build`. Your pull request must include any files created or updated as a result. Do not make any manual changes to the docs/ directory. Address any failures found in the build process, watching for schema validation failures. (The JSON schema for tasks is found in [lib/task_schema.json](./lib/task_schema.json).)
-* You can find step-by-step instructions for the contribution process [here](https://learn.mechanic.dev/advanced-topics/contributing-to-the-task-library). 
+* You can find step-by-step instructions for the contribution process [here](https://learn.mechanic.dev/resources/task-library/contributing). 
 
 Each contributor will be required to read and accept [our CLA](./CLA.md). When you file your first pull request, [the CLA assistant](https://github.com/marketplace/actions/cla-assistant-lite) will leave a comment, giving you a statement of agreement that you must paste into a comment of your own.
 

--- a/docs/find-duplicate-skus/README.md
+++ b/docs/find-duplicate-skus/README.md
@@ -1,0 +1,47 @@
+# Find all Exact Duplicate SKU's
+
+Tags: (not tagged!)
+
+This task scans your entire product library for Exact Match Duplicate SKU's and outputs a list of duplicate SKU's found.
+The report only contains one version of each SKU.
+The report is limited to 500 iterations of 250 variants (125,000 variants). 
+Empty SKUs will appear once.
+
+* View in the task library: [usemechanic.com/task/find-duplicate-skus](https://usemechanic.com/task/find-duplicate-skus)
+* Task JSON, for direct import: [task.json](../../tasks/find-duplicate-skus.json)
+* Preview task code: [script.liquid](./script.liquid)
+
+## Default options
+
+```json
+{
+  "exclude_inventory_not_tracked__boolean": true
+}
+```
+
+[Learn about task options in Mechanic](https://docs.usemechanic.com/article/471-task-options)
+
+## Subscriptions
+
+```liquid
+mechanic/user/trigger
+```
+
+[Learn about event subscriptions in Mechanic](https://docs.usemechanic.com/article/408-subscriptions)
+
+## Documentation
+
+This task scans your entire product library for Exact Match Duplicate SKU's and outputs a list of duplicate SKU's found.
+The report only contains one version of each SKU.
+The report is limited to 500 iterations of 250 variants (125,000 variants). 
+Empty SKUs will appear once.
+
+"Exclude inventory not tracked" will exclude any product thats inventory is not tracked in Shopify.
+
+## Installing this task
+
+Find this task [in the library at usemechanic.com](https://usemechanic.com/task/find-duplicate-skus), and use the "Try this task" button. Or, import [this task's JSON export](../../tasks/find-duplicate-skus.json) – see [Importing and exporting tasks](https://docs.usemechanic.com/article/505-importing-and-exporting-tasks) to learn how imports work.
+
+## Contributions
+
+Found a bug? Got an improvement to add? Start here: [../../CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/docs/find-duplicate-skus/script.liquid
+++ b/docs/find-duplicate-skus/script.liquid
@@ -1,0 +1,96 @@
+{% assign mappings = hash %}
+{% assign dups = hash %}
+{% assign cursor = nil %}
+
+{% for i in (0..500) %}
+
+  {% assign after = i | times: 250 %}
+  {% capture query %}
+  query {
+    productVariants(first:250, after: {{ cursor | json }}) {
+      pageInfo {
+        hasNextPage
+      }
+      edges {
+        node {
+          id
+          sku
+          inventoryItem{
+          tracked
+          }
+        }
+        cursor
+      }
+    }
+  }
+  {% endcapture %}
+  {% assign result = query | shopify %}
+
+  {% if event.preview %}
+    {% capture result_json %}
+    {
+      "data": {
+        "productVariants": {
+          "edges": [
+            {
+              "node": {
+                "id": "gid://shopify/ProductVariant/1234567890",
+                "sku": "sku123",
+                "inventoryItem": {
+                  "tracked": "true"
+                }
+              }
+            },
+            {
+              "node": {
+                "id": "gid://shopify/ProductVariant/123456789",
+                "sku": "sku123",
+                "inventoryItem": {
+                  "tracked": "true"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+    {% endcapture %}
+    {% assign result = result_json | parse_json %}
+  {% endif %}
+  
+  {% assign cursor = result.data.productVariants.edges.last.cursor %}
+  {% assign productVariants = result.data.productVariants.edges | map: "node" %}
+
+  {% for pv in productVariants %}
+    {% if pv.sku == null or pv.sku == empty %}
+      {% continue %}
+    {% endif %}
+    {% if options.exclude_inventory_not_tracked__boolean == true %}
+      {% if pv.inventoryItem.tracked == false %}
+        {% continue %}
+      {% endif %}
+    {% endif %}
+    {% assign existingPv = mappings[pv.sku] %}
+    {% if existingPv %}
+      {% if existingPv != pv.id %}
+        {% assign dups[pv.sku] = true %}
+      {% endif %}
+    {% else %}
+      {% assign mappings[pv.sku] = pv.id %}
+    {% endif %}
+  {% endfor %}
+
+  {% unless result.data.productVariants.pageInfo.hasNextPage %}
+    {% break %}
+  {% endunless %}
+
+{% endfor %}
+
+{% assign skus = productVariants | map:"sku" %}
+{% assign uniqskus = skus | uniq %}
+{% if skus.size == uniqskus.size %}
+  {% comment %}No exact duplicate SKUS {% endcomment %}
+  {%break %}
+{% endif %}
+
+{% action "echo" dups %}

--- a/tasks/find-duplicate-skus.json
+++ b/tasks/find-duplicate-skus.json
@@ -1,0 +1,16 @@
+{
+  "name": "Find all Exact Duplicate SKU's",
+  "options": {
+    "exclude_inventory_not_tracked__boolean": true
+  },
+  "subscriptions": [
+    "mechanic/user/trigger"
+  ],
+  "subscriptions_template": "mechanic/user/trigger",
+  "script": "{% assign mappings = hash %}\n{% assign dups = hash %}\n{% assign cursor = nil %}\n\n{% for i in (0..500) %}\n\n  {% assign after = i | times: 250 %}\n  {% capture query %}\n  query {\n    productVariants(first:250, after: {{ cursor | json }}) {\n      pageInfo {\n        hasNextPage\n      }\n      edges {\n        node {\n          id\n          sku\n          inventoryItem{\n          tracked\n          }\n        }\n        cursor\n      }\n    }\n  }\n  {% endcapture %}\n  {% assign result = query | shopify %}\n\n  {% if event.preview %}\n    {% capture result_json %}\n    {\n      \"data\": {\n        \"productVariants\": {\n          \"edges\": [\n            {\n              \"node\": {\n                \"id\": \"gid://shopify/ProductVariant/1234567890\",\n                \"sku\": \"sku123\",\n                \"inventoryItem\": {\n                  \"tracked\": \"true\"\n                }\n              }\n            },\n            {\n              \"node\": {\n                \"id\": \"gid://shopify/ProductVariant/123456789\",\n                \"sku\": \"sku123\",\n                \"inventoryItem\": {\n                  \"tracked\": \"true\"\n                }\n              }\n            }\n          ]\n        }\n      }\n    }\n    {% endcapture %}\n    {% assign result = result_json | parse_json %}\n  {% endif %}\n  \n  {% assign cursor = result.data.productVariants.edges.last.cursor %}\n  {% assign productVariants = result.data.productVariants.edges | map: \"node\" %}\n\n  {% for pv in productVariants %}\n    {% if pv.sku == null or pv.sku == empty %}\n      {% continue %}\n    {% endif %}\n    {% if options.exclude_inventory_not_tracked__boolean == true %}\n      {% if pv.inventoryItem.tracked == false %}\n        {% continue %}\n      {% endif %}\n    {% endif %}\n    {% assign existingPv = mappings[pv.sku] %}\n    {% if existingPv %}\n      {% if existingPv != pv.id %}\n        {% assign dups[pv.sku] = true %}\n      {% endif %}\n    {% else %}\n      {% assign mappings[pv.sku] = pv.id %}\n    {% endif %}\n  {% endfor %}\n\n  {% unless result.data.productVariants.pageInfo.hasNextPage %}\n    {% break %}\n  {% endunless %}\n\n{% endfor %}\n\n{% assign skus = productVariants | map:\"sku\" %}\n{% assign uniqskus = skus | uniq %}\n{% if skus.size == uniqskus.size %}\n  {% comment %}No exact duplicate SKUS {% endcomment %}\n  {%break %}\n{% endif %}\n\n{% action \"echo\" dups %}",
+  "docs": "This task scans your entire product library for Exact Match Duplicate SKU's and outputs a list of duplicate SKU's found.\nThe report only contains one version of each SKU.\nThe report is limited to 500 iterations of 250 variants (125,000 variants). \nEmpty SKUs will appear once.\n\n\"Exclude inventory not tracked\" will exclude any product thats inventory is not tracked in Shopify.",
+  "halt_action_run_sequence_on_error": false,
+  "online_store_javascript": null,
+  "order_status_javascript": null,
+  "perform_action_runs_in_sequence": false
+}


### PR DESCRIPTION
Update link for step-by-step instructions for the contribution process as it was wrong.

Add a new task to find all exact duplicate SKUs in a clients product list.