### PR TITLE
add a demonstration task, illustrating reconciliation of missing events

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -160,6 +160,7 @@ This directory is built automatically. Each task's documentation is generated fr
 * [Delete product or product variant metafields in bulk](./delete-product-or-product-variant-metafields-in-bulk)
 * [Delete the oldest x products from a specific collection](./delete-the-oldest-x-products-from-a-specific-collection)
 * [Delete variants having a metafield date that has passed](./delete-variants-having-a-metafield-date-that-has-passed)
+* [Demonstration: Auto-tag new orders, with scheduled reconciliation](./demonstration-auto-tag-new-orders-with-reconciliation)
 * [Demonstration: Fetch an external configuration file](./demonstration-fetch-an-external-configuration-file)
 * [Demonstration: Generate product sales report PDF with pie chart](./demonstration-generate-product-sales-report-pdf-with-pie-chart)
 * [Demonstration: Generating a file and uploading it to Shopify](./demonstration-generate-a-file-and-upload-to-shopify)

--- a/docs/demonstration-auto-tag-new-orders-with-reconciliation/README.md
+++ b/docs/demonstration-auto-tag-new-orders-with-reconciliation/README.md
@@ -1,0 +1,53 @@
+# Demonstration: Auto-tag new orders, with scheduled reconciliation
+
+Tags: Demonstration, Orders, Tag
+
+This task illustrates Shopify's recommendation of implementing reconciliation, in the case of missing Shopify events. This implementation handles the rare case that Shopify fails to deliver a webhook (orders/create, in this example), by scanning for unprocessed orders every 15 minutes.
+
+* View in the task library: [usemechanic.com/task/demonstration-auto-tag-new-orders-with-reconciliation](https://usemechanic.com/task/demonstration-auto-tag-new-orders-with-reconciliation)
+* Task JSON, for direct import: [task.json](../../tasks/demonstration-auto-tag-new-orders-with-reconciliation.json)
+* Preview task code: [script.liquid](./script.liquid)
+
+## Default options
+
+```json
+{
+  "run_on_order_create__boolean": true,
+  "reconcile_every_15_minutes__boolean": true,
+  "reconcile_on_manual_run__boolean": true
+}
+```
+
+[Learn about task options in Mechanic](https://docs.usemechanic.com/article/471-task-options)
+
+## Subscriptions
+
+```liquid
+{% if options.run_on_order_create__boolean %}
+  shopify/orders/create
+{% endif %}
+
+{% if options.reconcile_every_15_minutes__boolean %}
+  mechanic/scheduler/15min
+{% endif %}
+
+{% if options.reconcile_on_manual_run__boolean %}
+  mechanic/user/trigger
+{% endif %}
+```
+
+[Learn about event subscriptions in Mechanic](https://docs.usemechanic.com/article/408-subscriptions)
+
+## Documentation
+
+This task illustrates Shopify's recommendation of implementing reconciliation, in the case of missing Shopify events. This implementation handles the rare case that Shopify fails to deliver a webhook (orders/create, in this example), by scanning for unprocessed orders every 15 minutes.
+
+To learn more about this kind of scenario, see https://learn.mechanic.dev/core/shopify/events/reconciling-missing-events.
+
+## Installing this task
+
+Find this task [in the library at usemechanic.com](https://usemechanic.com/task/demonstration-auto-tag-new-orders-with-reconciliation), and use the "Try this task" button. Or, import [this task's JSON export](../../tasks/demonstration-auto-tag-new-orders-with-reconciliation.json) – see [Importing and exporting tasks](https://docs.usemechanic.com/article/505-importing-and-exporting-tasks) to learn how imports work.
+
+## Contributions
+
+Found a bug? Got an improvement to add? Start here: [../../CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/docs/demonstration-auto-tag-new-orders-with-reconciliation/script.liquid
+++ b/docs/demonstration-auto-tag-new-orders-with-reconciliation/script.liquid
@@ -1,0 +1,111 @@
+{% assign order_processed_tag = "processed-by-autotagger" %}
+
+{% assign order_ids_to_process = array %}
+
+{% if event.topic contains "shopify/orders/" %}
+  {% if event.preview %}
+    {% assign order = hash %}
+    {% assign order["admin_graphql_api_id"] = "gid://shopify/Order/1234567890" %}
+  {% endif %}
+
+  {% assign order_tags = order.tags | split: ", " %}
+  {% if order_tags contains order_processed_tag %}
+    {% log message: "Order is already processed; skipping" %}
+  {% else %}
+    {% assign order_ids_to_process[order_ids_to_process.size] = order.admin_graphql_api_id %}
+  {% endif %}
+{% elsif event.topic contains "mechanic/scheduler/" or event.topic == "mechanic/user/trigger" %}
+  {% assign cursor = nil %}
+  
+  {% assign orders_query_parts = array %}
+  {% assign orders_query_parts[0] = order_processed_tag | json | prepend: "-tag:" %}
+  {% assign orders_query_parts[1] = "now - 15 minutes" | date: "%Y-%m-%dT%H:%M:%SZ", tz: "UTC" | json | prepend: "created_at:>=" %}
+  {% assign orders_query = orders_query_parts | join: " " %}
+  
+  {% log orders_query: orders_query %}
+  
+  {% for n in (0..100) %}
+    {% capture query %}
+      query {
+        orders(
+          first: 250
+          after: {{ cursor | json }}
+          query: {{ orders_query | json }}
+        ) {
+          pageInfo {
+            hasNextPage
+          }
+          edges {
+            cursor
+            node {
+              id
+              tags
+            }
+          }
+        }
+      }
+    {% endcapture %}
+  
+    {% assign result = query | shopify %}
+  
+    {% if event.preview %}
+      {% capture result_json %}
+        {
+          "data": {
+            "orders": {
+              "edges": [
+                {
+                  "node": {
+                    "id": "gid://shopify/Order/1234567890",
+                    "tags": []
+                  }
+                }
+              ]
+            }
+          }
+        }
+      {% endcapture %}
+  
+      {% assign result = result_json | parse_json %}
+    {% endif %}
+  
+    {% for order_edge in result.data.orders.edges %}
+      {% comment %}
+        Double-checking this, to ward against stale search results from the API.
+      {% endcomment %}
+      {% unless order_edge.node.tags contains order_processed_tag %}
+        {% assign order_ids_to_process[order_ids_to_process.size] = order_edge.node.id %}
+      {% endunless %}
+    {% endfor %}
+  
+    {% if result.data.orders.pageInfo.hasNextPage %}
+      {% assign cursor = result.data.orders.edges.last.cursor %}
+    {% else %}
+      {% break %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
+{% for order_id_to_process in order_ids_to_process %}
+  {% action "shopify" %}
+    mutation {
+      tagsAdd(
+        id: {{ order_id_to_process | json }}
+        tags: [{{ order_processed_tag | json }}]
+      ) {
+        node {
+          # retrieving some post-tagging data, to ease debugging
+          ... on Order {
+            id
+            name
+            tags
+          }
+        }
+        userErrors {
+          field
+          message
+        }
+      }
+    }
+  {% endaction %}
+{% endfor %}

--- a/tasks/demonstration-auto-tag-new-orders-with-reconciliation.json
+++ b/tasks/demonstration-auto-tag-new-orders-with-reconciliation.json
@@ -1,0 +1,25 @@
+{
+  "name": "Demonstration: Auto-tag new orders, with scheduled reconciliation",
+  "options": {
+    "run_on_order_create__boolean": true,
+    "reconcile_every_15_minutes__boolean": true,
+    "reconcile_on_manual_run__boolean": true
+  },
+  "subscriptions": [
+    "shopify/orders/create",
+    "mechanic/scheduler/15min",
+    "mechanic/user/trigger"
+  ],
+  "subscriptions_template": "{% if options.run_on_order_create__boolean %}\n  shopify/orders/create\n{% endif %}\n\n{% if options.reconcile_every_15_minutes__boolean %}\n  mechanic/scheduler/15min\n{% endif %}\n\n{% if options.reconcile_on_manual_run__boolean %}\n  mechanic/user/trigger\n{% endif %}",
+  "script": "{% assign order_processed_tag = \"processed-by-autotagger\" %}\n\n{% assign order_ids_to_process = array %}\n\n{% if event.topic contains \"shopify/orders/\" %}\n  {% if event.preview %}\n    {% assign order = hash %}\n    {% assign order[\"admin_graphql_api_id\"] = \"gid://shopify/Order/1234567890\" %}\n  {% endif %}\n\n  {% assign order_tags = order.tags | split: \", \" %}\n  {% if order_tags contains order_processed_tag %}\n    {% log message: \"Order is already processed; skipping\" %}\n  {% else %}\n    {% assign order_ids_to_process[order_ids_to_process.size] = order.admin_graphql_api_id %}\n  {% endif %}\n{% elsif event.topic contains \"mechanic/scheduler/\" or event.topic == \"mechanic/user/trigger\" %}\n  {% assign cursor = nil %}\n  \n  {% assign orders_query_parts = array %}\n  {% assign orders_query_parts[0] = order_processed_tag | json | prepend: \"-tag:\" %}\n  {% assign orders_query_parts[1] = \"now - 15 minutes\" | date: \"%Y-%m-%dT%H:%M:%SZ\", tz: \"UTC\" | json | prepend: \"created_at:>=\" %}\n  {% assign orders_query = orders_query_parts | join: \" \" %}\n  \n  {% log orders_query: orders_query %}\n  \n  {% for n in (0..100) %}\n    {% capture query %}\n      query {\n        orders(\n          first: 250\n          after: {{ cursor | json }}\n          query: {{ orders_query | json }}\n        ) {\n          pageInfo {\n            hasNextPage\n          }\n          edges {\n            cursor\n            node {\n              id\n              tags\n            }\n          }\n        }\n      }\n    {% endcapture %}\n  \n    {% assign result = query | shopify %}\n  \n    {% if event.preview %}\n      {% capture result_json %}\n        {\n          \"data\": {\n            \"orders\": {\n              \"edges\": [\n                {\n                  \"node\": {\n                    \"id\": \"gid://shopify/Order/1234567890\",\n                    \"tags\": []\n                  }\n                }\n              ]\n            }\n          }\n        }\n      {% endcapture %}\n  \n      {% assign result = result_json | parse_json %}\n    {% endif %}\n  \n    {% for order_edge in result.data.orders.edges %}\n      {% comment %}\n        Double-checking this, to ward against stale search results from the API.\n      {% endcomment %}\n      {% unless order_edge.node.tags contains order_processed_tag %}\n        {% assign order_ids_to_process[order_ids_to_process.size] = order_edge.node.id %}\n      {% endunless %}\n    {% endfor %}\n  \n    {% if result.data.orders.pageInfo.hasNextPage %}\n      {% assign cursor = result.data.orders.edges.last.cursor %}\n    {% else %}\n      {% break %}\n    {% endif %}\n  {% endfor %}\n{% endif %}\n\n{% for order_id_to_process in order_ids_to_process %}\n  {% action \"shopify\" %}\n    mutation {\n      tagsAdd(\n        id: {{ order_id_to_process | json }}\n        tags: [{{ order_processed_tag | json }}]\n      ) {\n        node {\n          # retrieving some post-tagging data, to ease debugging\n          ... on Order {\n            id\n            name\n            tags\n          }\n        }\n        userErrors {\n          field\n          message\n        }\n      }\n    }\n  {% endaction %}\n{% endfor %}",
+  "docs": "This task illustrates Shopify's recommendation of implementing reconciliation, in the case of missing Shopify events. This implementation handles the rare case that Shopify fails to deliver a webhook (orders/create, in this example), by scanning for unprocessed orders every 15 minutes.\n\nTo learn more about this kind of scenario, see https://learn.mechanic.dev/core/shopify/events/reconciling-missing-events.",
+  "halt_action_run_sequence_on_error": false,
+  "online_store_javascript": null,
+  "order_status_javascript": null,
+  "perform_action_runs_in_sequence": false,
+  "tags": [
+    "Demonstration",
+    "Orders",
+    "Tag"
+  ]
+}


### PR DESCRIPTION
Related discussion: https://usemechanic.slack.com/archives/CURE65U2W/p1632825406327200

Related documentation: https://learn.mechanic.dev/core/shopify/events/reconciling-missing-events