### PR TITLE
new task: schedule theme publishing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -236,6 +236,7 @@ This directory is built automatically. Each task's documentation is generated fr
 * [Schedule a storefront banner](./schedule-a-storefront-banner)
 * [Schedule customer auto-tagging after a purchase](./schedule-customer-auto-tagging-after-a-purchase)
 * [Schedule product tags by date](./schedule-product-tags-by-date)
+* [Scheduled theme publishing](./scheduled-theme-publishing)
 * [Send a PDF invoice when an order is created](./send-a-pdf-invoice-when-an-order-is-created)
 * [Send a customer signup email](./customer-signup-email)
 * [Send a follow-up email after order cancellation](./send-a-follow-up-email-after-order-cancellation)

--- a/docs/scheduled-theme-publishing/README.md
+++ b/docs/scheduled-theme-publishing/README.md
@@ -1,0 +1,51 @@
+# Scheduled theme publishing
+
+Tags: Publish, Schedule
+
+This task will allow you to schedule any number of themes to be published at future dates and times. When the task runs at its normally scheduled 10 minute interval, it will find the entry with the most recent configured date in the past, and if that theme is not currently published, then the task will publish it.
+
+* View in the task library: [usemechanic.com/task/scheduled-theme-publishing](https://usemechanic.com/task/scheduled-theme-publishing)
+* Task JSON, for direct import: [task.json](../../tasks/scheduled-theme-publishing.json)
+* Preview task code: [script.liquid](./script.liquid)
+
+## Default options
+
+```json
+{
+  "theme_ids_and_publish_dates__keyval": null
+}
+```
+
+[Learn about task options in Mechanic](https://docs.usemechanic.com/article/471-task-options)
+
+## Subscriptions
+
+```liquid
+mechanic/scheduler/10min
+mechanic/user/trigger
+```
+
+[Learn about event subscriptions in Mechanic](https://docs.usemechanic.com/article/408-subscriptions)
+
+## Documentation
+
+This task will allow you to schedule any number of themes to be published at future dates and times. When the task runs at its normally scheduled 10 minute interval, it will find the entry with the most recent configured date in the past, and if that theme is not currently published, then the task will publish it.
+
+Within the *Theme IDs and publish dates* field, simply configure the theme IDs on the left along with the related publish dates on the right. Publish dates may be entered with a date and time, using a 24-hour clock, in the format **YYYY-MM-DD HH:MM**, or only with a date in the format **YYYY-MM-DD**, in which case the time would default to midnight.
+
+*Important notes:*
+- All times are in local shop time.
+- The task will attempt to parse the configured dates and times, and will display an error at run time if any of them are unparsable in the expected format.
+- While this task is active it may override any manual publishing actions.
+
+## Installing this task
+
+Find this task [in the library at usemechanic.com](https://usemechanic.com/task/scheduled-theme-publishing), and use the "Try this task" button. Or, import [this task's JSON export](../../tasks/scheduled-theme-publishing.json) – see [Importing and exporting tasks](https://docs.usemechanic.com/article/505-importing-and-exporting-tasks) to learn how imports work.
+
+## Contributions
+
+Found a bug? Got an improvement to add? Start here: [../../CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Task requests
+
+Submit your [task requests](https://mechanic.canny.io/task-requests) for consideration by the Mechanic community, and they may be chosen for development and inclusion in the [task library](https://tasks.mechanic.dev/)!

--- a/docs/scheduled-theme-publishing/script.liquid
+++ b/docs/scheduled-theme-publishing/script.liquid
@@ -1,0 +1,83 @@
+{% assign theme_ids_and_publish_dates = options.theme_ids_and_publish_dates__keyval %}
+
+{% if event.preview %}
+  {% assign theme_to_publish = hash %}
+  {% assign theme_to_publish["id"] = 1234567890 %}
+
+{% elsif event.topic == "mechanic/user/trigger" or event.topic contains "mechanic/scheduler/" %}
+  {% assign shop_theme_ids = shop.themes | map: "id" %}
+
+  {% assign publication_candidates = array %}
+
+  {% for keyval in theme_ids_and_publish_dates %}
+    {% assign theme_id = keyval.first %}
+    {% assign publish_date = keyval.last %}
+
+    {% assign theme = shop.themes[theme_id] %}
+
+    {% if theme == blank %}
+      {% error
+        message: "A theme with this id was not found in this shop.",
+        theme_id: theme_id,
+        shop_theme_ids: shop_theme_ids
+      %}
+    {% endif %}
+
+    {% assign valid_publish_date = publish_date | parse_date: "%Y-%m-%d %H:%M" %}
+
+    {% unless valid_publish_date %}
+      {% assign valid_publish_date = publish_date | parse_date: "%Y-%m-%d" %}
+    {% endunless %}
+
+    {% if valid_publish_date == blank %}
+      {% error
+        message: "A theme publish date could not be parsed. Refer to the task documentation for valid date/time formats.",
+        theme_id: theme_id,
+        publish_date: publish_date
+      %}
+    {% endif %}
+
+    {% assign publication_candidate = hash %}
+    {% assign publication_candidate["theme"] = theme %}
+    {% assign publication_candidate["publish_date"] = valid_publish_date | date: "%s" %}
+    {% assign publication_candidates = publication_candidates | push: publication_candidate %}
+  {% endfor %}
+
+  {% assign publication_candidates = publication_candidates | sort: "publish_date" %}
+
+  {% assign now = "now" | date: "%s" %}
+  {% assign theme_to_publish = nil %}
+
+  {% for publication_candidate in publication_candidates %}
+    {% if publication_candidate.publish_date <= now %}
+      {% assign theme_to_publish = publication_candidate.theme %}
+
+    {% else %}
+      {% break %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
+{% if theme_to_publish != blank %}
+  {% if theme_to_publish.role == "main" %}
+    {% log
+      message: "The theme to be published is already set as the main theme on the shop; skipping.",
+      theme_to_publish: theme_to_publish
+    %}
+
+  {% else %}
+    {% action "shopify" %}
+      [
+        "update",
+        "theme",
+        {
+          "id": {{ theme_to_publish.id }},
+          "role": "main"
+        }
+      ]
+    {% endaction %}
+  {% endif %}
+
+{% else %}
+  {% log "No themes qualify to be published based on their configured publish dates." %}
+{% endif %}

--- a/tasks/scheduled-theme-publishing.json
+++ b/tasks/scheduled-theme-publishing.json
@@ -1,0 +1,21 @@
+{
+  "name": "Scheduled theme publishing",
+  "options": {
+    "theme_ids_and_publish_dates__keyval": null
+  },
+  "subscriptions": [
+    "mechanic/scheduler/10min",
+    "mechanic/user/trigger"
+  ],
+  "subscriptions_template": "mechanic/scheduler/10min\nmechanic/user/trigger",
+  "script": "{% assign theme_ids_and_publish_dates = options.theme_ids_and_publish_dates__keyval %}\n\n{% if event.preview %}\n  {% assign theme_to_publish = hash %}\n  {% assign theme_to_publish[\"id\"] = 1234567890 %}\n\n{% elsif event.topic == \"mechanic/user/trigger\" or event.topic contains \"mechanic/scheduler/\" %}\n  {% assign shop_theme_ids = shop.themes | map: \"id\" %}\n\n  {% assign publication_candidates = array %}\n\n  {% for keyval in theme_ids_and_publish_dates %}\n    {% assign theme_id = keyval.first %}\n    {% assign publish_date = keyval.last %}\n\n    {% assign theme = shop.themes[theme_id] %}\n\n    {% if theme == blank %}\n      {% error\n        message: \"A theme with this id was not found in this shop.\",\n        theme_id: theme_id,\n        shop_theme_ids: shop_theme_ids\n      %}\n    {% endif %}\n\n    {% assign valid_publish_date = publish_date | parse_date: \"%Y-%m-%d %H:%M\" %}\n\n    {% unless valid_publish_date %}\n      {% assign valid_publish_date = publish_date | parse_date: \"%Y-%m-%d\" %}\n    {% endunless %}\n\n    {% if valid_publish_date == blank %}\n      {% error\n        message: \"A theme publish date could not be parsed. Refer to the task documentation for valid date/time formats.\",\n        theme_id: theme_id,\n        publish_date: publish_date\n      %}\n    {% endif %}\n\n    {% assign publication_candidate = hash %}\n    {% assign publication_candidate[\"theme\"] = theme %}\n    {% assign publication_candidate[\"publish_date\"] = valid_publish_date | date: \"%s\" %}\n    {% assign publication_candidates = publication_candidates | push: publication_candidate %}\n  {% endfor %}\n\n  {% assign publication_candidates = publication_candidates | sort: \"publish_date\" %}\n\n  {% assign now = \"now\" | date: \"%s\" %}\n  {% assign theme_to_publish = nil %}\n\n  {% for publication_candidate in publication_candidates %}\n    {% if publication_candidate.publish_date <= now %}\n      {% assign theme_to_publish = publication_candidate.theme %}\n\n    {% else %}\n      {% break %}\n    {% endif %}\n  {% endfor %}\n{% endif %}\n\n{% if theme_to_publish != blank %}\n  {% if theme_to_publish.role == \"main\" %}\n    {% log\n      message: \"The theme to be published is already set as the main theme on the shop; skipping.\",\n      theme_to_publish: theme_to_publish\n    %}\n\n  {% else %}\n    {% action \"shopify\" %}\n      [\n        \"update\",\n        \"theme\",\n        {\n          \"id\": {{ theme_to_publish.id }},\n          \"role\": \"main\"\n        }\n      ]\n    {% endaction %}\n  {% endif %}\n\n{% else %}\n  {% log \"No themes qualify to be published based on their configured publish dates.\" %}\n{% endif %}",
+  "docs": "This task will allow you to schedule any number of themes to be published at future dates and times. When the task runs at its normally scheduled 10 minute interval, it will find the entry with the most recent configured date in the past, and if that theme is not currently published, then the task will publish it.\n\nWithin the *Theme IDs and publish dates* field, simply configure the theme IDs on the left along with the related publish dates on the right. Publish dates may be entered with a date and time, using a 24-hour clock, in the format **YYYY-MM-DD HH:MM**, or only with a date in the format **YYYY-MM-DD**, in which case the time would default to midnight.\n\n*Important notes:*\n- All times are in local shop time.\n- The task will attempt to parse the configured dates and times, and will display an error at run time if any of them are unparsable in the expected format.\n- While this task is active it may override any manual publishing actions.",
+  "halt_action_run_sequence_on_error": false,
+  "online_store_javascript": null,
+  "order_status_javascript": null,
+  "perform_action_runs_in_sequence": false,
+  "tags": [
+    "Publish",
+    "Schedule"
+  ]
+}


### PR DESCRIPTION
[Community requested task](https://mechanic.canny.io/task-requests/p/publish-a-theme-at-a-scheduled-date-and-time)

Development notes:
- The key value field seemed like the best solution to allow for single, toggling, and several themes in rotation publishing options 
- The key value field was made optional so that the task can be saved without entries (for example, when a sale event is done, and the merchant wishes to return to manual updating of themes without interference form the task)
- A shop metafield setting indicating that a configured theme had already been published by the task was considered, which would prevent the task from overriding manual theme publishing until the the next configured publish date passes. Decided to wait and see what feedback merchants give when using the task first to see if that is useful.
- Might want to consider adding a "Theme" tag for this task. The build script won't allow it currently.