### PR TITLE
update "Auto-tag orders created from drafts"

### DIFF
--- a/docs/auto-tag-orders-created-from-drafts/script.liquid
+++ b/docs/auto-tag-orders-created-from-drafts/script.liquid
@@ -1,8 +1,58 @@
-{% if event.preview or order.source_name == "shopify_draft_order" %}
+{% assign order_qualifies = false %}
+
+{% if order.source_name == "shopify_draft_order" %}
+  {% assign order_qualifies = true %}
+{% elsif order.source_name == "1830279" %}
+  {% comment %}
+    1830279 is the ID of the "Shopify Web" app. If we're seeing it here, it means that
+    the order was created via the /admin area.
+  {% endcomment %}
+
+  {% capture query %}
+    query {
+      order(id: {{ order.admin_graphql_api_id | json }}) {
+        app {
+          name
+        }
+      }
+    }
+  {% endcapture %}
+
+  {% assign result = query | shopify %}
+
+  {% if event.preview %}
+    {% capture result_json %}
+      {
+        "data": {
+          "order": {
+            "app": {
+              "name": "Draft Orders"
+            }
+          }
+        }
+      }
+    {% endcapture %}
+
+    {% assign result = result_json | parse_json %}
+  {% endif %}
+
+  {% if result.data.order.app.name == "Draft Orders" %}
+    {% assign order_qualifies = true %}
+  {% else %}
+    {% log message: "Order does not qualify",
+        order_source_name: order.source_name,
+        order_app_name: result.data.order.app.name %}
+  {% endif %}
+{% else %}
+  {% log message: "Order does not qualify",
+      order_source_name: order.source_name %}
+{% endif %}
+
+{% if order_qualifies %}
   {% action "shopify" %}
     mutation {
       tagsAdd(
-        id: {{ order.admin_graphql_api_id | default: "gid://shopify/Order/1234567890" | json }}
+        id: {{ order.admin_graphql_api_id | json }}
         tags: {{ options.tag_to_add__required | json }}
       ) {
         userErrors {

--- a/tasks/auto-tag-orders-created-from-drafts.json
+++ b/tasks/auto-tag-orders-created-from-drafts.json
@@ -1,18 +1,53 @@
 {
-  "name": "Auto-tag orders created from drafts",
-  "options": {
-    "tag_to_add__required": "from-draft"
-  },
-  "subscriptions": [
-    "shopify/orders/create"
-  ],
-  "subscriptions_template": "shopify/orders/create",
-  "script": "{% if event.preview or order.source_name == \"shopify_draft_order\" %}\n  {% action \"shopify\" %}\n    mutation {\n      tagsAdd(\n        id: {{ order.admin_graphql_api_id | default: \"gid://shopify/Order/1234567890\" | json }}\n        tags: {{ options.tag_to_add__required | json }}\n      ) {\n        userErrors {\n          field\n          message\n        }\n      }\n    }\n  {% endaction %}\n{% endif %}",
   "docs": "This task monitors for newly-created orders, and auto-tags any that were originally based on a Shopify draft order, using the tag of your choice.",
   "halt_action_run_sequence_on_error": false,
+  "name": "Auto-tag orders created from drafts",
   "online_store_javascript": null,
   "order_status_javascript": null,
   "perform_action_runs_in_sequence": false,
+  "script": "{% assign order_qualifies = false %}\n\n{% if order.source_name == \"shopify_draft_order\" %}\n  {% assign order_qualifies = true %}\n{% elsif order.source_name == \"1830279\" %}\n  {% comment %}\n    1830279 is the ID of the \"Shopify Web\" app. If we're seeing it here, it means that\n    the order was created via the /admin area.\n  {% endcomment %}\n\n  {% capture query %}\n    query {\n      order(id: {{ order.admin_graphql_api_id | json }}) {\n        app {\n          name\n        }\n      }\n    }\n  {% endcapture %}\n\n  {% assign result = query | shopify %}\n\n  {% if event.preview %}\n    {% capture result_json %}\n      {\n        \"data\": {\n          \"order\": {\n            \"app\": {\n              \"name\": \"Draft Orders\"\n            }\n          }\n        }\n      }\n    {% endcapture %}\n\n    {% assign result = result_json | parse_json %}\n  {% endif %}\n\n  {% if result.data.order.app.name == \"Draft Orders\" %}\n    {% assign order_qualifies = true %}\n  {% else %}\n    {% log message: \"Order does not qualify\",\n        order_source_name: order.source_name,\n        order_app_name: result.data.order.app.name %}\n  {% endif %}\n{% else %}\n  {% log message: \"Order does not qualify\",\n      order_source_name: order.source_name %}\n{% endif %}\n\n{% if order_qualifies %}\n  {% action \"shopify\" %}\n    mutation {\n      tagsAdd(\n        id: {{ order.admin_graphql_api_id | json }}\n        tags: {{ options.tag_to_add__required | json }}\n      ) {\n        userErrors {\n          field\n          message\n        }\n      }\n    }\n  {% endaction %}\n{% endif %}",
+  "subscriptions_template": "shopify/orders/create",
+  "subscriptions": [
+    "shopify/orders/create"
+  ],
+  "preview_event_definitions": [
+    {
+      "description": "An order with an app name of \"Draft Orders\"",
+      "event_attributes": {
+        "topic": "shopify/orders/create",
+        "data": {
+          "id": 1234567890,
+          "admin_graphql_api_id": "gid://shopify/Order/1234567890",
+          "source_name": "1830279"
+        }
+      }
+    },
+    {
+      "description": "An order with a source name of \"shopify_draft_order\"",
+      "event_attributes": {
+        "topic": "shopify/orders/create",
+        "data": {
+          "id": 1234567890,
+          "admin_graphql_api_id": "gid://shopify/Order/1234567890",
+          "source_name": "shopify_draft_order"
+        }
+      }
+    },
+    {
+      "description": "An order that does not qualify",
+      "event_attributes": {
+        "topic": "shopify/orders/create",
+        "data": {
+          "id": 1234567890,
+          "admin_graphql_api_id": "gid://shopify/Order/1234567890",
+          "source_name": "web"
+        }
+      }
+    }
+  ],
+  "options": {
+    "tag_to_add__required": "from-draft"
+  },
   "tags": [
     "Auto-Tag",
     "Draft Orders",


### PR DESCRIPTION
... to work with Shopify's current methods of identifying draft orders