### PR TITLE
new task: remove an order tag when an another tag is added

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -240,6 +240,7 @@ This directory is built automatically. Each task's documentation is generated fr
 * [Remind customers after x days about unpaid orders](./remind-customers-after-x-days-about-unpaid-orders)
 * [Remind customers that their order is on the way](./remind-customers-that-their-order-is-on-the-way)
 * [Remove a customer tag when another tag is added](./remove-a-customer-tag-when-another-tag-is-added)
+* [Remove an order tag when another tag is added](./remove-a-order-tag-when-another-tag-is-added)
 * [Report Toaster: Deliver report PDF via email or Slack](./report-toaster-deliver-report-pdf-via-email-or-slack)
 * [Report Toaster: Pirate Ship Integration](./report-toaster-pirateship-integration)
 * [Report Toaster: ShipStation Integration](./report-toaster-shipstation-integration)

--- a/docs/remove-a-order-tag-when-another-tag-is-added/README.md
+++ b/docs/remove-a-order-tag-when-another-tag-is-added/README.md
@@ -1,0 +1,45 @@
+# Remove an order tag when another tag is added
+
+Tags: Orders, Untag, Watch
+
+Does exactly as it says. :)
+
+* View in the task library: [tasks.mechanic.dev/remove-a-order-tag-when-another-tag-is-added](https://tasks.mechanic.dev/remove-a-order-tag-when-another-tag-is-added)
+* Task JSON, for direct import: [task.json](../../tasks/remove-a-order-tag-when-another-tag-is-added.json)
+* Preview task code: [script.liquid](./script.liquid)
+
+## Default options
+
+```json
+{
+  "order_tag_to_watch_for__required": "apple",
+  "order_tag_to_remove__required": "butter",
+  "ignore_tag_case__boolean": true
+}
+```
+
+[Learn about task options in Mechanic](https://learn.mechanic.dev/core/tasks/options)
+
+## Subscriptions
+
+```liquid
+shopify/orders/updated
+```
+
+[Learn about event subscriptions in Mechanic](https://learn.mechanic.dev/core/tasks/subscriptions)
+
+## Documentation
+
+Does exactly as it says. :)
+
+## Installing this task
+
+Find this task [in the library at tasks.mechanic.dev](https://tasks.mechanic.dev/remove-a-order-tag-when-another-tag-is-added), and use the "Try this task" button. Or, import [this task's JSON export](../../tasks/remove-a-order-tag-when-another-tag-is-added.json) – see [Importing and exporting tasks](https://learn.mechanic.dev/core/tasks/import-and-export) to learn how imports work.
+
+## Contributions
+
+Found a bug? Got an improvement to add? Start here: [../../CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Task requests
+
+Submit your [task requests](https://mechanic.canny.io/task-requests) for consideration by the Mechanic community, and they may be chosen for development and inclusion in the [task library](https://tasks.mechanic.dev/)!

--- a/docs/remove-a-order-tag-when-another-tag-is-added/script.liquid
+++ b/docs/remove-a-order-tag-when-another-tag-is-added/script.liquid
@@ -1,0 +1,31 @@
+{% if event.preview %}
+  {% assign order = hash %}
+  {% assign order["admin_graphql_api_id"] = "gid://shopify/Order/1234567890" %}
+  {% assign order["tags"] = options.order_tag_to_watch_for__required | append: ", " | append: options.order_tag_to_remove__required %}
+{% endif %}
+
+{% assign order_tags = order.tags | split: ", " %}
+{% assign tag_to_match = options.order_tag_to_watch_for__required %}
+{% assign tag_to_remove = options.order_tag_to_remove__required %}
+
+{% if options.ignore_tag_case__boolean %}
+  {% assign order_tags = order.tags | downcase | split: ", " %}
+  {% assign tag_to_match = options.order_tag_to_watch_for__required | downcase %}
+  {% assign tag_to_remove = options.order_tag_to_remove__required | downcase %}
+{% endif %}
+
+{% if order_tags contains tag_to_match and order_tags contains tag_to_remove %}
+  {% action "shopify" %}
+    mutation {
+      tagsRemove(
+        id: {{ order.admin_graphql_api_id | json }}
+        tags: {{ options.order_tag_to_remove__required | json }}
+      ) {
+        userErrors {
+          field
+          message
+        }
+      }
+    }
+  {% endaction %}
+{% endif %}

--- a/tasks/remove-a-order-tag-when-another-tag-is-added.json
+++ b/tasks/remove-a-order-tag-when-another-tag-is-added.json
@@ -1,0 +1,24 @@
+{
+  "name": "Remove an order tag when another tag is added",
+  "options": {
+    "order_tag_to_watch_for__required": "apple",
+    "order_tag_to_remove__required": "butter",
+    "ignore_tag_case__boolean": true
+  },
+  "script": "{% if event.preview %}\n  {% assign order = hash %}\n  {% assign order[\"admin_graphql_api_id\"] = \"gid://shopify/Order/1234567890\" %}\n  {% assign order[\"tags\"] = options.order_tag_to_watch_for__required | append: \", \" | append: options.order_tag_to_remove__required %}\n{% endif %}\n\n{% assign order_tags = order.tags | split: \", \" %}\n{% assign tag_to_match = options.order_tag_to_watch_for__required %}\n{% assign tag_to_remove = options.order_tag_to_remove__required %}\n\n{% if options.ignore_tag_case__boolean %}\n  {% assign order_tags = order.tags | downcase | split: \", \" %}\n  {% assign tag_to_match = options.order_tag_to_watch_for__required | downcase %}\n  {% assign tag_to_remove = options.order_tag_to_remove__required | downcase %}\n{% endif %}\n\n{% if order_tags contains tag_to_match and order_tags contains tag_to_remove %}\n  {% action \"shopify\" %}\n    mutation {\n      tagsRemove(\n        id: {{ order.admin_graphql_api_id | json }}\n        tags: {{ options.order_tag_to_remove__required | json }}\n      ) {\n        userErrors {\n          field\n          message\n        }\n      }\n    }\n  {% endaction %}\n{% endif %}",
+  "subscriptions": [
+    "shopify/orders/updated"
+  ],
+  "online_store_javascript": null,
+  "order_status_javascript": null,
+  "docs": "Does exactly as it says. :)",
+  "subscriptions_template": "shopify/orders/updated",
+  "perform_action_runs_in_sequence": false,
+  "halt_action_run_sequence_on_error": false,
+  "preview_event_definitions": [],
+  "tags": [
+    "Orders",
+    "Untag",
+    "Watch"
+  ]
+}


### PR DESCRIPTION
Based on this task: https://tasks.mechanic.dev/remove-a-customer-tag-when-another-tag-is-added

but orders, instead of customers :)