### PR TITLE
new task: auto copy customer metafields to order attributes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ This directory is built automatically. Each task's documentation is generated fr
 * [Auto-capture payments when an order is created](./auto-capture-payments-when-an-order-is-created)
 * [Auto-complete new draft orders](./auto-complete-new-draft-orders)
 * [Auto-connect new products to all locations](./auto-connect-new-products-to-all-locations)
+* [Auto-copy customer metafields to new orders](./auto-copy-customer-metafields-to-new-orders)
 * [Auto-copy notes from customers to their orders](./auto-copy-notes-from-customers-to-their-orders)
 * [Auto-copy order notes to the customer's note](./auto-copy-order-notes-to-the-customers-note)
 * [Auto-create collections by product type or vendor](./auto-create-collections-by-product-type-or-vendor)

--- a/docs/auto-copy-customer-metafields-to-new-orders/README.md
+++ b/docs/auto-copy-customer-metafields-to-new-orders/README.md
@@ -1,0 +1,47 @@
+# Auto-copy customer metafields to new orders
+
+Tags: Customers, Metafields, Order Attributes, Orders
+
+When new orders are created, this task will check to see if the customer has any of the configured metafields, and if so it will copy the metafield values to the paired order attributes.
+
+* View in the task library: [tasks.mechanic.dev/auto-copy-customer-metafields-to-new-orders](https://tasks.mechanic.dev/auto-copy-customer-metafields-to-new-orders)
+* Task JSON, for direct import: [task.json](../../tasks/auto-copy-customer-metafields-to-new-orders.json)
+* Preview task code: [script.liquid](./script.liquid)
+
+## Default options
+
+```json
+{
+  "customer_metafields_and_order_attributes__keyval_required": {}
+}
+```
+
+[Learn about task options in Mechanic](https://learn.mechanic.dev/core/tasks/options)
+
+## Subscriptions
+
+```liquid
+shopify/orders/create
+```
+
+[Learn about event subscriptions in Mechanic](https://learn.mechanic.dev/core/tasks/subscriptions)
+
+## Documentation
+
+When new orders are created, this task will check to see if the customer has any of the configured metafields, and if so it will copy the metafield values to the paired order attributes.
+
+Configure this task by adding customer metafields on the left, in the form of __namespace.key__, and the order attribute names on the right.
+
+_Example configuration:_ "custom.group": "Group"
+
+## Installing this task
+
+Find this task [in the library at tasks.mechanic.dev](https://tasks.mechanic.dev/auto-copy-customer-metafields-to-new-orders), and use the "Try this task" button. Or, import [this task's JSON export](../../tasks/auto-copy-customer-metafields-to-new-orders.json) – see [Importing and exporting tasks](https://learn.mechanic.dev/core/tasks/import-and-export) to learn how imports work.
+
+## Contributions
+
+Found a bug? Got an improvement to add? Start here: [../../CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Task requests
+
+Submit your [task requests](https://mechanic.canny.io/task-requests) for consideration by the Mechanic community, and they may be chosen for development and inclusion in the [task library](https://tasks.mechanic.dev/)!

--- a/docs/auto-copy-customer-metafields-to-new-orders/script.liquid
+++ b/docs/auto-copy-customer-metafields-to-new-orders/script.liquid
@@ -1,0 +1,97 @@
+{% assign customer_metafields_and_order_attributes = options.customer_metafields_and_order_attributes__keyval_required %}
+
+{% capture query %}
+  query {
+    order(id: {{ order.admin_graphql_api_id | json }}) {
+      id
+      customer {
+        metafields(
+          first: {{ customer_metafields_and_order_attributes.size }}
+          keys: {{ customer_metafields_and_order_attributes | keys | json }}
+        ) {
+          nodes {
+            key
+            value
+          }
+        }
+      }
+      customAttributes {
+        key
+        value
+      }
+    }
+  }
+{% endcapture %}
+
+{% assign result = query | shopify %}
+
+{% if event.preview %}
+  {% capture result_json %}
+    {
+      "data": {
+        "order": {
+          "id": "gid://shopify/Order/1234567890",
+          "customer": {
+            "metafields": {
+              "nodes": [
+                {
+                  "key": {{ customer_metafields_and_order_attributes | first | first | json }},
+                  "value": "Alpha"
+                }
+              ]
+            }
+          },
+          "customAttributes": [
+            {
+              "key": "__sample",
+              "value": "Beta"
+            }
+          ]
+        }
+      }
+    }
+  {% endcapture %}
+
+  {% assign result = result_json | parse_json %}
+{% endif %}
+
+{% assign metafields = result.data.order.customer.metafields.nodes %}
+{% assign attributes = result.data.order.customAttributes | default: array %}
+
+{% log
+  existing_attributes_on_order: attributes,
+  matched_customer_metafields: metafields
+%}
+
+{% for metafield in metafields %}
+  {% assign attribute = hash %}
+  {% assign attribute["key"] = customer_metafields_and_order_attributes[metafield.key] %}
+  {% assign attribute["value"] = metafield.value %}
+  {% assign attributes = attributes | push: attribute %}
+{% else %}
+  {% break %}
+{% endfor %}
+
+{% action "shopify" %}
+  mutation {
+    orderUpdate(
+      input: {
+        id: {{ order.admin_graphql_api_id | json }}
+        customAttributes: {{ attributes | graphql_arguments }}
+      }
+    ) {
+      order {
+        id
+        name
+        customAttributes {
+          key
+          value
+        }
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+{% endaction %}

--- a/tasks/auto-copy-customer-metafields-to-new-orders.json
+++ b/tasks/auto-copy-customer-metafields-to-new-orders.json
@@ -1,0 +1,23 @@
+{
+  "docs": "When new orders are created, this task will check to see if the customer has any of the configured metafields, and if so it will copy the metafield values to the paired order attributes.\n\nConfigure this task by adding customer metafields on the left, in the form of __namespace.key__, and the order attribute names on the right.\n\n_Example configuration:_ \"custom.group\": \"Group\"",
+  "halt_action_run_sequence_on_error": false,
+  "name": "Auto-copy customer metafields to new orders",
+  "online_store_javascript": null,
+  "options": {
+    "customer_metafields_and_order_attributes__keyval_required": {}
+  },
+  "order_status_javascript": null,
+  "perform_action_runs_in_sequence": false,
+  "preview_event_definitions": [],
+  "script": "{% assign customer_metafields_and_order_attributes = options.customer_metafields_and_order_attributes__keyval_required %}\n\n{% capture query %}\n  query {\n    order(id: {{ order.admin_graphql_api_id | json }}) {\n      id\n      customer {\n        metafields(\n          first: {{ customer_metafields_and_order_attributes.size }}\n          keys: {{ customer_metafields_and_order_attributes | keys | json }}\n        ) {\n          nodes {\n            key\n            value\n          }\n        }\n      }\n      customAttributes {\n        key\n        value\n      }\n    }\n  }\n{% endcapture %}\n\n{% assign result = query | shopify %}\n\n{% if event.preview %}\n  {% capture result_json %}\n    {\n      \"data\": {\n        \"order\": {\n          \"id\": \"gid://shopify/Order/1234567890\",\n          \"customer\": {\n            \"metafields\": {\n              \"nodes\": [\n                {\n                  \"key\": {{ customer_metafields_and_order_attributes | first | first | json }},\n                  \"value\": \"Alpha\"\n                }\n              ]\n            }\n          },\n          \"customAttributes\": [\n            {\n              \"key\": \"__sample\",\n              \"value\": \"Beta\"\n            }\n          ]\n        }\n      }\n    }\n  {% endcapture %}\n\n  {% assign result = result_json | parse_json %}\n{% endif %}\n\n{% assign metafields = result.data.order.customer.metafields.nodes %}\n{% assign attributes = result.data.order.customAttributes | default: array %}\n\n{% log\n  existing_attributes_on_order: attributes,\n  matched_customer_metafields: metafields\n%}\n\n{% for metafield in metafields %}\n  {% assign attribute = hash %}\n  {% assign attribute[\"key\"] = customer_metafields_and_order_attributes[metafield.key] %}\n  {% assign attribute[\"value\"] = metafield.value %}\n  {% assign attributes = attributes | push: attribute %}\n{% else %}\n  {% break %}\n{% endfor %}\n\n{% action \"shopify\" %}\n  mutation {\n    orderUpdate(\n      input: {\n        id: {{ order.admin_graphql_api_id | json }}\n        customAttributes: {{ attributes | graphql_arguments }}\n      }\n    ) {\n      order {\n        id\n        name\n        customAttributes {\n          key\n          value\n        }\n      }\n      userErrors {\n        field\n        message\n      }\n    }\n  }\n{% endaction %}",
+  "subscriptions": [
+    "shopify/orders/create"
+  ],
+  "subscriptions_template": "shopify/orders/create",
+  "tags": [
+    "Customers",
+    "Metafields",
+    "Order Attributes",
+    "Orders"
+  ]
+}


### PR DESCRIPTION
New task from community request list.

Dev notes:
This task takes advantage of the new, alternate way to access metafields, by passing the namespace and key together as the key. And the metafields node can also now be filtered by an array of shortcut metafield keys, which matches up perfectly with the keys of the task configuration field.