### PR TITLE
new task: auto-tag open orders from same customer and shipping address

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -98,6 +98,7 @@ This directory is built automatically. Each task's documentation is generated fr
 * [Auto-tag new orders with their fulfillment locations](./auto-tag-new-orders-with-their-fulfillment-locations)
 * [Auto-tag new orders](./auto-tag-new-orders)
 * [Auto-tag new products by "back in stock" age](./auto-tag-new-products-by-back-in-stock-age)
+* [Auto-tag open orders from the same customer with the same shipping address](./auto-tag-open-orders-from-same-customer-and-shipping-address)
 * [Auto-tag orders based on cart attributes](./auto-tag-orders-based-on-cart-attributes)
 * [Auto-tag orders based on customer account tags](./auto-tag-orders-based-on-customer-account-tags)
 * [Auto-tag orders based on shipping method](./auto-tag-orders-based-on-shipping-method)

--- a/docs/auto-tag-open-orders-from-same-customer-and-shipping-address/README.md
+++ b/docs/auto-tag-open-orders-from-same-customer-and-shipping-address/README.md
@@ -1,0 +1,43 @@
+# Auto-tag open orders from the same customer with the same shipping address
+
+Tags: Auto-Tag, Orders, Shipping
+
+When a new order is created, this task will tag all open orders for the customer which match the new order's shipping address, giving you the potential to combine shipments.
+
+* View in the task library: [tasks.mechanic.dev/auto-tag-open-orders-from-same-customer-and-shipping-address](https://tasks.mechanic.dev/auto-tag-open-orders-from-same-customer-and-shipping-address)
+* Task JSON, for direct import: [task.json](../../tasks/auto-tag-open-orders-from-same-customer-and-shipping-address.json)
+* Preview task code: [script.liquid](./script.liquid)
+
+## Default options
+
+```json
+{
+  "tag_to_apply__required": "combine_check"
+}
+```
+
+[Learn about task options in Mechanic](https://learn.mechanic.dev/core/tasks/options)
+
+## Subscriptions
+
+```liquid
+shopify/orders/create
+```
+
+[Learn about event subscriptions in Mechanic](https://learn.mechanic.dev/core/tasks/subscriptions)
+
+## Documentation
+
+When a new order is created, this task will tag all open orders for the customer which match the new order's shipping address, giving you the potential to combine shipments.
+
+## Installing this task
+
+Find this task [in the library at tasks.mechanic.dev](https://tasks.mechanic.dev/auto-tag-open-orders-from-same-customer-and-shipping-address), and use the "Try this task" button. Or, import [this task's JSON export](../../tasks/auto-tag-open-orders-from-same-customer-and-shipping-address.json) – see [Importing and exporting tasks](https://learn.mechanic.dev/core/tasks/import-and-export) to learn how imports work.
+
+## Contributions
+
+Found a bug? Got an improvement to add? Start here: [../../CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Task requests
+
+Submit your [task requests](https://mechanic.canny.io/task-requests) for consideration by the Mechanic community, and they may be chosen for development and inclusion in the [task library](https://tasks.mechanic.dev/)!

--- a/docs/auto-tag-open-orders-from-same-customer-and-shipping-address/script.liquid
+++ b/docs/auto-tag-open-orders-from-same-customer-and-shipping-address/script.liquid
@@ -1,0 +1,151 @@
+{% assign tag_to_apply = options.tag_to_apply__required %}
+
+{% comment %}
+  -- stub data for the preview event
+{% endcomment %}
+
+{% if event.preview %}
+  {% assign order = hash %}
+  {% assign order["admin_graphql_api_id"] = "gid://shopify/Order/2345678901" %}
+  {% assign order["shipping_address"] = "not null" %}
+{% endif %}
+
+{% comment %}
+  -- need an order shipping address to match; otherwise exit this task run
+{% endcomment %}
+
+{% if order.shipping_address == blank %}
+  {% log "This order does not have a shipping address; exiting this task run" %}
+  {% break %}
+{% endif %}
+
+{% comment %}
+  -- query all open orders for this customer
+{% endcomment %}
+
+{% capture query %}
+  query {
+    customer(
+      id: {{ order.customer.admin_graphql_api_id | json }}
+    ) {
+      orders(
+        first: 100
+        sortKey: CREATED_AT
+        reverse: true
+        query: "status:open"
+      ) {
+        nodes {
+          id
+          tags
+          shippingAddress {
+            formatted
+          }
+        }
+      }
+    }
+  }
+{% endcapture %}
+
+{% assign result = query | shopify %}
+
+{% comment %} Stub data for the preview event {% endcomment %}
+{% if event.preview %}
+  {% capture result_json %}
+    {
+      "data": {
+        "customer": {
+          "orders": {
+            "nodes": [
+              {
+                "id": "gid://shopify/Order/2345678901",
+                "shippingAddress": {
+                  "formatted": [
+                    "123 Main Street",
+                    "Santa Monica CA 90405",
+                    "United States"
+                  ]
+                }
+              },
+              {
+                "id": "gid://shopify/Order/1234567890",
+                "shippingAddress": {
+                  "formatted": [
+                    "123 Main Street",
+                    "Santa Monica CA 90405",
+                    "United States"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  {% endcapture %}
+
+  {% assign result = result_json | parse_json %}
+{% endif %}
+
+{% assign orders = result.data.customer.orders.nodes %}
+
+{% comment %}
+  -- need at least 2 open orders to apply the tag; otherwise exit this task run
+{% endcomment %}
+
+{% if orders.size < 2 %}
+  {% break %}
+{% endif %}
+
+{% comment %}
+  -- get formatted shipping address from the order that initiated this event (this is not available in the webhook data)
+{% endcomment %}
+
+{% assign shipping_address_to_match
+  = orders
+  | where: "id", order.admin_graphql_api_id
+  | map: "shippingAddress"
+  | map: "formatted"
+  | first
+%}
+
+{% comment %}
+  -- search open orders for matching shipping address
+{% endcomment %}
+
+{% assign matched_orders = array %}
+
+{% for order in orders %}
+  {% if order.shippingAddress.formatted == shipping_address_to_match %}
+    {% assign matched_orders = matched_orders | push: order %}
+  {% endif %}
+{% endfor %}
+
+{% comment %}
+  -- if no other open orders for this customer match the shipping address from the order that initiated this event, then exit this task run
+{% endcomment %}
+
+{% if matched_orders.size == 1 %}
+  {% break %}
+{% endif %}
+
+{% comment %}
+  -- add tag to matched orders unless they already have it
+{% endcomment %}
+
+{% for order in matched_orders %}
+  {% unless order.tags contains tag_to_apply %}
+    {% action "shopify" %}
+      mutation {
+        tagsAdd(
+          id: {{ order.id | json }}
+          tags: {{ tag_to_apply | json }}
+        ) {
+          userErrors {
+            field
+            message
+          }
+        }
+      }
+    {% endaction %}
+  {% endunless %}
+{% endfor %}

--- a/tasks/auto-tag-open-orders-from-same-customer-and-shipping-address.json
+++ b/tasks/auto-tag-open-orders-from-same-customer-and-shipping-address.json
@@ -1,0 +1,22 @@
+{
+  "docs": "When a new order is created, this task will tag all open orders for the customer which match the new order's shipping address, giving you the potential to combine shipments.",
+  "halt_action_run_sequence_on_error": false,
+  "name": "Auto-tag open orders from the same customer with the same shipping address",
+  "online_store_javascript": null,
+  "options": {
+    "tag_to_apply__required": "combine_check"
+  },
+  "order_status_javascript": null,
+  "perform_action_runs_in_sequence": false,
+  "preview_event_definitions": [],
+  "script": "{% assign tag_to_apply = options.tag_to_apply__required %}\n\n{% comment %}\n  -- stub data for the preview event\n{% endcomment %}\n\n{% if event.preview %}\n  {% assign order = hash %}\n  {% assign order[\"admin_graphql_api_id\"] = \"gid://shopify/Order/2345678901\" %}\n  {% assign order[\"shipping_address\"] = \"not null\" %}\n{% endif %}\n\n{% comment %}\n  -- need an order shipping address to match; otherwise exit this task run\n{% endcomment %}\n\n{% if order.shipping_address == blank %}\n  {% log \"This order does not have a shipping address; exiting this task run\" %}\n  {% break %}\n{% endif %}\n\n{% comment %}\n  -- query all open orders for this customer\n{% endcomment %}\n\n{% capture query %}\n  query {\n    customer(\n      id: {{ order.customer.admin_graphql_api_id | json }}\n    ) {\n      orders(\n        first: 100\n        sortKey: CREATED_AT\n        reverse: true\n        query: \"status:open\"\n      ) {\n        nodes {\n          id\n          tags\n          shippingAddress {\n            formatted\n          }\n        }\n      }\n    }\n  }\n{% endcapture %}\n\n{% assign result = query | shopify %}\n\n{% comment %} Stub data for the preview event {% endcomment %}\n{% if event.preview %}\n  {% capture result_json %}\n    {\n      \"data\": {\n        \"customer\": {\n          \"orders\": {\n            \"nodes\": [\n              {\n                \"id\": \"gid://shopify/Order/2345678901\",\n                \"shippingAddress\": {\n                  \"formatted\": [\n                    \"123 Main Street\",\n                    \"Santa Monica CA 90405\",\n                    \"United States\"\n                  ]\n                }\n              },\n              {\n                \"id\": \"gid://shopify/Order/1234567890\",\n                \"shippingAddress\": {\n                  \"formatted\": [\n                    \"123 Main Street\",\n                    \"Santa Monica CA 90405\",\n                    \"United States\"\n                  ]\n                }\n              }\n            ]\n          }\n        }\n      }\n    }\n  {% endcapture %}\n\n  {% assign result = result_json | parse_json %}\n{% endif %}\n\n{% assign orders = result.data.customer.orders.nodes %}\n\n{% comment %}\n  -- need at least 2 open orders to apply the tag; otherwise exit this task run\n{% endcomment %}\n\n{% if orders.size < 2 %}\n  {% break %}\n{% endif %}\n\n{% comment %}\n  -- get formatted shipping address from the order that initiated this event (this is not available in the webhook data)\n{% endcomment %}\n\n{% assign shipping_address_to_match\n  = orders\n  | where: \"id\", order.admin_graphql_api_id\n  | map: \"shippingAddress\"\n  | map: \"formatted\"\n  | first\n%}\n\n{% comment %}\n  -- search open orders for matching shipping address\n{% endcomment %}\n\n{% assign matched_orders = array %}\n\n{% for order in orders %}\n  {% if order.shippingAddress.formatted == shipping_address_to_match %}\n    {% assign matched_orders = matched_orders | push: order %}\n  {% endif %}\n{% endfor %}\n\n{% comment %}\n  -- if no other open orders for this customer match the shipping address from the order that initiated this event, then exit this task run\n{% endcomment %}\n\n{% if matched_orders.size == 1 %}\n  {% break %}\n{% endif %}\n\n{% comment %}\n  -- add tag to matched orders unless they already have it\n{% endcomment %}\n\n{% for order in matched_orders %}\n  {% unless order.tags contains tag_to_apply %}\n    {% action \"shopify\" %}\n      mutation {\n        tagsAdd(\n          id: {{ order.id | json }}\n          tags: {{ tag_to_apply | json }}\n        ) {\n          userErrors {\n            field\n            message\n          }\n        }\n      }\n    {% endaction %}\n  {% endunless %}\n{% endfor %}\n",
+  "subscriptions": [
+    "shopify/orders/create"
+  ],
+  "subscriptions_template": "shopify/orders/create",
+  "tags": [
+    "Auto-Tag",
+    "Orders",
+    "Shipping"
+  ]
+}


### PR DESCRIPTION
Requested by community - https://mechanic.canny.io/task-requests/p/tag-order-to-help-combine-shipping