### PR TITLE
Docs index: Group tasks by tags

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -339,3 +339,1400 @@ This directory is built automatically. Each task's documentation is generated fr
 * [Untag orders when paid](./untag-orders-when-paid)
 * [Update empty customer data from addresses](./update-empty-customer-data-from-addresses)
 * [Update product description when out of stock](./update-product-description-when-out-of-stock)
+
+
+## Tasks grouped by tags
+
+### Abandoned Checkout
+
+* [Abandoned checkout emails](./abandoned-checkout-emails)
+
+### Access Control
+
+* [Auto-tag customers with Locksmith passcodes used](./auto-tag-customers-with-locksmith-passcodes-used)
+
+### Account
+
+* [Auto-verify customer email addresses](./auto-verify-customer-email-addresses)
+* [Send account invites to all customers in bulk](./send-account-invites-to-all-customers-in-bulk)
+
+### Active
+
+* [Schedule product status to active](./schedule-product-status-to-active)
+
+### Address
+
+* [Auto-tag orders with mismatching billing and shipping addresses](./auto-tag-orders-with-mismatching-billing-and-shipping-addresses)
+* [Email vendors when an order shipping address changes](./email-vendors-when-an-order-shipping-address-changes)
+* [Update empty customer data from addresses](./update-empty-customer-data-from-addresses)
+
+### Admin Link
+
+* [Auto-add bundle components to orders, post-purchase](./auto-add-bundle-components-to-orders-post-purchase)
+* [Send a PDF when an order is sent to Mechanic](./send-a-pdf-when-an-order-is-sent-to-mechanic)
+
+### Advanced
+
+* [Advanced: Scheduled Price Changes](./advanced-scheduled-price-changes)
+* [Advanced: Scheduled section publishing](./advanced-scheduled-section-publishing)
+
+### Age
+
+* [Auto-tag products by age](./auto-tag-new-products-by-age)
+
+### Alert
+
+* [Catalog update email](./catalog-update-email)
+* [Email someone specific based on a new order's customer tags](./email-someone-specific-based-on-a-new-orders-customer-tags)
+* [Email someone when a certain product is purchased](./email-someone-when-certain-product-purchased)
+* [Flag orders that aren't fulfilled after several days](./flag-orders-that-arent-fulfilled-after-two-days)
+* [Get email alerts for FBA failures](./get-email-alerts-for-fba-failures)
+* [Get email alerts for out of stock products](./get-email-alerts-for-out-of-stock-products)
+* [Receive email alerts when inventory levels change](./receive-email-alerts-when-inventory-levels-change)
+* [Send a staff notification email for each delivery](./send-a-staff-notification-email-for-each-delivery)
+* [Send an email alert on fulfillment failure](./fulfillment-failure-email)
+* [Send an email alert when a customer changes state](./send-an-email-alert-when-a-customer-changes-state)
+* [Send an email alert when a customer places more than 2 orders in 24 hours](./send-an-email-alert-when-a-customer-places-more-than-2-orders-in-24-hours)
+* [Send an email alert when a fulfillment is cancelled](./send-an-email-alert-when-a-fulfillment-is-cancelled)
+* [Send an email alert when a variant hits 0 total inventory](./send-an-email-alert-when-a-variant-hits-0-total-inventory)
+* [Send an email alert when an incoming Canadian order has an unsupported FSA](./send-an-email-alert-when-an-incoming-canadian-order-has-an-unsupported-fsa)
+* [Send email when an order comes in](./send-email-when-an-order-comes-in)
+
+### Archive
+
+* [Archive free orders on fulfillment](./archive-free-orders-on-fulfillment)
+* [Archive orders on delivery](./archive-orders-on-delivery)
+* [Archive orders when fulfilled](./archive-orders-when-fulfilled)
+* [Archive orders when tagged](./archive-orders-when-tagged)
+* [Auto-archive orders after fulfillment](./auto-archive-orders-after-fulfillment)
+
+### Auto-Tag
+
+* [Auto-remove a product tag x days after it's added](./auto-remove-a-product-tag-x-days-after-its-added)
+* [Auto-tag a customer's first order](./auto-tag-a-customers-first-order)
+* [Auto-tag cancelled orders](./auto-tag-cancelled-orders)
+* [Auto-tag customers based on discount codes used](./auto-tag-customers-based-on-discount-codes-used)
+* [Auto-tag customers based on email domain](./auto-tag-customers-by-email-domain)
+* [Auto-tag customers by order app](./auto-tag-customers-by-order-app)
+* [Auto-tag customers by purchased SKUs](./auto-tag-customers-by-purchased-skus)
+* [Auto-tag customers by sales channel](./auto-tag-customers-by-sales-channel)
+* [Auto-tag customers having a rolling minimum total spend](./auto-tag-customers-having-a-rolling-minimum-total-spend)
+* [Auto-tag customers that accept marketing](./auto-tag-customers-that-accept-marketing)
+* [Auto-tag customers when another tag is added](./auto-tag-customers-when-another-tag-is-added)
+* [Auto-tag customers when their order is paid](./auto-tag-customers-when-order-paid)
+* [Auto-tag customers when their order is tagged](./auto-tag-customers-when-their-order-is-tagged)
+* [Auto-tag customers when they purchase a matching product](./auto-tag-customers-upon-product-purchase)
+* [Auto-tag customers who purchase an item on sale](./auto-tag-customers-who-purchase-an-item-on-sale)
+* [Auto-tag customers with Locksmith passcodes used](./auto-tag-customers-with-locksmith-passcodes-used)
+* [Auto-tag customers with product tags from their order](./tag-customers-with-product-tags-from-their-order)
+* [Auto-tag customers with the location of their purchase](./auto-tag-customers-with-the-location-of-their-purchase)
+* [Auto-tag customers with vendors after ordering](./auto-tag-customers-with-vendors-after-ordering)
+* [Auto-tag customers with who have accounts](./auto-tag-customers-with-who-have-accounts)
+* [Auto-tag customers within a purchase range](./auto-tag-customers-within-a-purchase-range)
+* [Auto-tag draft orders by originating staff member](./auto-tag-draft-orders-by-originating-staff-member)
+* [Auto-tag fulfilled orders by carrier](./auto-tag-fulfilled-orders-by-carrier)
+* [Auto-tag fulfilled orders with their carriers](./auto-tag-fulfilled-orders-with-their-carriers)
+* [Auto-tag new customers with the current date](./auto-tag-customers-with-the-current-date)
+* [Auto-tag new customers](./auto-tag-new-customers)
+* [Auto-tag new draft orders](./auto-tag-new-draft-orders)
+* [Auto-tag new online orders by web browser](./auto-tag-new-online-orders-by-web-browser)
+* [Auto-tag new orders based on payment method](./auto-tag-new-orders-based-on-payment-method)
+* [Auto-tag new orders by staff member](./auto-tag-new-orders-by-staff-member)
+* [Auto-tag new orders using Liquid](./auto-tag-new-orders-using-liquid)
+* [Auto-tag new orders using the customer's tags](./auto-tag-orders-using-the-customers-tags)
+* [Auto-tag new orders with a value from the customer note](./auto-tag-new-orders-with-a-value-from-the-customer-note)
+* [Auto-tag new orders with product SKUs](./auto-tag-new-orders-with-product-skus)
+* [Auto-tag new orders with their fulfillment locations](./auto-tag-new-orders-with-their-fulfillment-locations)
+* [Auto-tag new orders](./auto-tag-new-orders)
+* [Auto-tag new products by "back in stock" age](./auto-tag-new-products-by-back-in-stock-age)
+* [Auto-tag open orders from the same customer with the same shipping address](./auto-tag-open-orders-from-same-customer-and-shipping-address)
+* [Auto-tag orders based on cart attributes](./auto-tag-orders-based-on-cart-attributes)
+* [Auto-tag orders based on customer account tags](./auto-tag-orders-based-on-customer-account-tags)
+* [Auto-tag orders based on shipping method](./auto-tag-orders-based-on-shipping-method)
+* [Auto-tag orders by app](./auto-tag-orders-by-app)
+* [Auto-tag orders by discount code](./auto-tag-orders-by-discount-code)
+* [Auto-tag orders by financial status](./auto-tag-orders-by-financial-status)
+* [Auto-tag orders by originating staff member](./auto-tag-orders-by-originating-staff-member)
+* [Auto-tag orders by product collections](./auto-tag-orders-by-product-collections)
+* [Auto-tag orders by sales channel](./auto-tag-orders-by-sales-channel)
+* [Auto-tag orders by shipment status](./auto-tag-orders-by-shipment-status)
+* [Auto-tag orders by shipping address city](./auto-tag-orders-by-shipping-address-city)
+* [Auto-tag orders by shipping address country](./auto-tag-orders-by-shipping-address-country)
+* [Auto-tag orders by their risk level](./auto-tag-orders-by-their-risk-level)
+* [Auto-tag orders created from drafts](./auto-tag-orders-created-from-drafts)
+* [Auto-tag orders from recurring client IP addresses](./auto-tag-orders-from-recurring-client-ip-addresses)
+* [Auto-tag orders that are ready to ship](./auto-tag-orders-that-are-ready-to-ship)
+* [Auto-tag orders that contain a matching product](./auto-tag-orders-that-contain-a-matching-product)
+* [Auto-tag orders that contain an out of stock item](./auto-tag-orders-that-contain-an-out-of-stock-item)
+* [Auto-tag orders that contain subscription products](./auto-tag-orders-that-contain-subscription-products)
+* [Auto-tag orders that do not have a certain tag](./auto-tag-orders-that-do-not-have-a-certain-tag)
+* [Auto-tag orders using product tags](./auto-tag-orders-using-product-tags)
+* [Auto-tag orders when another tag is added](./auto-tag-orders-when-another-tag-is-added)
+* [Auto-tag orders when paid](./auto-tag-orders-when-paid)
+* [Auto-tag orders with UTM parameters](./auto-tag-orders-with-utm-parameters)
+* [Auto-tag orders with a cart attribute](./auto-tag-orders-with-a-cart-attribute)
+* [Auto-tag orders with chargeback or inquiry activity](./auto-tag-orders-with-chargeback-or-inquiry-activity)
+* [Auto-tag orders with customer tags when new customer tags are added](./tag-orders-with-customer-tags-when-customer-is-tagged)
+* [Auto-tag orders with mismatching billing and shipping addresses](./auto-tag-orders-with-mismatching-billing-and-shipping-addresses)
+* [Auto-tag orders with product tags](./auto-tag-orders-with-product-tags)
+* [Auto-tag orders with product vendors](./auto-tag-orders-with-product-vendors)
+* [Auto-tag orders with their line item properties](./auto-tag-orders-with-their-line-item-properties)
+* [Auto-tag orders with their tracking numbers](./auto-tag-orders-with-their-tracking-numbers)
+* [Auto-tag out-of-stock products](./auto-tag-out-of-stock-products)
+* [Auto-tag products based on their product type](./auto-tag-products-based-on-their-product-type)
+* [Auto-tag products based on their publishing status](./auto-tag-products-based-on-their-publishing-status)
+* [Auto-tag products by age](./auto-tag-new-products-by-age)
+* [Auto-tag products by largest available size](./auto-tag-products-by-largest-available-size)
+* [Auto-tag products by their options](./auto-tag-products-by-their-options)
+* [Auto-tag products by their publish date](./auto-tag-products-by-their-publish-date)
+* [Auto-tag products in a manual collection](./auto-tag-products-in-a-manual-collection)
+* [Auto-tag products that are missing costs](./auto-tag-products-that-are-missing-costs)
+* [Auto-tag products that have a "compare at" price](./auto-tag-products-that-have-a-compare-at-price)
+* [Auto-tag products that meet a sales threshold](./auto-tag-products-that-meet-a-sales-threshold)
+* [Auto-tag products when another tag is added](./auto-tag-products-when-another-tag-is-added)
+* [Auto-tag products when their variants change](./auto-tag-products-when-their-skus-change)
+* [Auto-tag products with incoming inventory](./auto-tag-products-with-incoming-inventory)
+* [Auto-tag products with their vendors](./auto-tag-products-with-their-vendors)
+* [Auto-tag products without descriptions](./auto-tag-products-without-descriptions)
+* [Copy order and/or product tags to customers](./copy-order-tags-to-customers)
+* [Maintain a tag for orders processed today](./maintain-a-tag-for-orders-processed-today)
+* [Schedule customer auto-tagging after a purchase](./schedule-customer-auto-tagging-after-a-purchase)
+* [Schedule product tags by date](./schedule-product-tags-by-date)
+* [Sync an inverse customer tag](./sync-an-inverse-customer-tag)
+* [Sync an inverse order tag](./sync-an-inverse-order-tag)
+* [Tag customers when their last order is before/after x days ago](./tag-customers-when-their-last-order-is-before-after-x-days-ago)
+* [Tag online orders by ?ls= Locksmith secret link used](./tag-orders-by-locksmith-secret-link)
+* [Tag online orders by their ?ref= referral codes](./tag-orders-by-url-referrer)
+* [Tag orders in bulk by order name](./tag-orders-in-bulk-by-order-name)
+* [Tag orders that have at least x of a certain product](./tag-orders-that-have-at-least-x-of-a-certain-product)
+* [Tag products as in- or out-of-stock, by location ID](./tag-products-as-in-or-out-of-stock-by-location-id)
+* [Tag products as in- or out-of-stock](./tag-products-as-in-or-out-of-stock)
+* [Tag products by their price ranges](./tag-products-by-their-price-ranges)
+
+### Auto-Update
+
+* [Auto-associate variants with a delivery profile, by metafield value](./auto-associate-variants-with-a-delivery-profile-by-metafield-value)
+* [Auto-update inventory policy based on a "preorder" tag](./auto-update-inventory-policy-based-on-a-preorder-tag)
+
+### Backups
+
+* [Backup inventory to SFTP in Shopify CSV format](./backup-scheduled-inventory-exports-in-shopifys-csv-format)
+* [Export all products to SFTP, as a Shopify-friendly CSV](./export-all-products-to-sftp-as-a-shopify-friendly-csv)
+
+### Banner
+
+* [Schedule a storefront banner](./schedule-a-storefront-banner)
+
+### Barcodes
+
+* [Keep SKUs up to date with barcodes](./keep-skus-up-to-date-with-barcodes)
+
+### Bulk
+
+* [Add all products to a certain sales channel](./add-all-products-to-a-certain-sales-channel)
+* [Auto-tag products when another tag is added](./auto-tag-products-when-another-tag-is-added)
+* [Auto-tag products with incoming inventory](./auto-tag-products-with-incoming-inventory)
+* [Bulk capture orders by order number](./bulk-capture-by-order-number)
+* [Delete customer metafields in bulk](./delete-customer-metafields-in-bulk)
+* [Delete product or product variant metafields in bulk](./delete-product-or-product-variant-metafields-in-bulk)
+* [Maintain collections by product metafield values](./maintain-collections-by-product-metafield-values)
+* [Reset negative inventory levels to zero in bulk](./reset-negative-inventory-levels-to-zero-in-bulk)
+* [Send account invites to all customers in bulk](./send-account-invites-to-all-customers-in-bulk)
+* [Set product or variant metafields values in bulk](./set-product-or-variant-metafields-in-bulk)
+* [Tag orders in bulk by order name](./tag-orders-in-bulk-by-order-name)
+* [Unpublish products from markets when locations are out of stock](./unpublish-products-from-markets-when-locations-are-out-of-stock)
+
+### Bulk Action Link
+
+* [Send a PDF when an order is sent to Mechanic](./send-a-pdf-when-an-order-is-sent-to-mechanic)
+
+### Bundle
+
+* [Auto-add bundle components to orders, post-purchase](./auto-add-bundle-components-to-orders-post-purchase)
+* [Auto-tag orders that contain bundles](./auto-tag-orders-that-contain-bundles)
+* [Maintain inventory for a product bundle](./maintain-inventory-for-a-product-bundle)
+
+### CSV
+
+* [Backup inventory to SFTP in Shopify CSV format](./backup-scheduled-inventory-exports-in-shopifys-csv-format)
+* [Email a CSV export of orders](./email-a-csv-export-of-orders)
+* [Email a CSV export of products](./email-a-csv-export-of-products)
+* [Export a CSV of order shipping addresses](./export-a-csv-of-order-shipping-addresses)
+* [Export all products to SFTP, as a Shopify-friendly CSV](./export-all-products-to-sftp-as-a-shopify-friendly-csv)
+* [Generate a report of orders that still require payment](./generate-a-report-of-orders-that-still-require-payment)
+
+### Cancel
+
+* [Auto-cancel fulfillments when an order is tagged](./auto-cancel-fulfillments-when-an-order-is-tagged)
+* [Auto-cancel orders with too many of a certain SKU](./auto-cancel-orders-with-too-many-of-a-certain-sku)
+* [Auto-tag cancelled orders](./auto-tag-cancelled-orders)
+* [Automatically cancel high-risk orders](./automatically-cancel-high-risk-orders)
+* [Automatically cancel orders with certain risk indicators](./automatically-cancel-orders-with-certain-risk-indicators)
+* [Cancel and close unpaid orders after x hours/days](./cancel-and-close-unpaid-orders-after-two-days)
+* [Cancel fulfillments when an order is fully refunded](./cancel-fulfillments-when-an-order-is-fully-refunded)
+* [Reissue single-use discount codes after order cancellation](./reissue-single-use-discount-codes-after-order-cancellation)
+* [Send a follow-up email after order cancellation](./send-a-follow-up-email-after-order-cancellation)
+
+### Cart
+
+* [Auto-tag orders with a cart attribute](./auto-tag-orders-with-a-cart-attribute)
+* [Create a draft order from the cart](./create-a-draft-order-from-the-cart)
+
+### Cart Attributes
+
+* [Auto-tag orders based on cart attributes](./auto-tag-orders-based-on-cart-attributes)
+* [Auto-tag orders with a cart attribute](./auto-tag-orders-with-a-cart-attribute)
+* [Send a new-order email to someone based on a cart attribute](./send-a-new-order-email-to-someone-based-on-a-cart-attribute)
+
+### Catalog
+
+* [Generate a simple product catalog PDF](./generate-a-simple-product-catalog-pdf)
+
+### Collections
+
+* [Auto-add products to a custom collection when tagged](./auto-add-products-to-a-custom-collection-when-tagged)
+* [Auto-create collections by product type or vendor](./auto-create-collections-by-product-type-or-vendor)
+* [Auto-sort collections by inventory levels](./auto-sort-collections-by-inventory-levels)
+* [Auto-sort collections by product properties](./auto-sort-collections-by-product-properties)
+* [Auto-tag orders by product collections](./auto-tag-orders-by-product-collections)
+* [Auto-tag products in a manual collection](./auto-tag-products-in-a-manual-collection)
+* [Delete the oldest x products from a specific collection](./delete-the-oldest-x-products-from-a-specific-collection)
+* [Maintain a collection of new products](./maintain-a-collection-of-new-products)
+* [Maintain a collection of recently purchased products](./maintain-a-collection-of-recently-purchased-products)
+* [Maintain collections by product metafield values](./maintain-collections-by-product-metafield-values)
+* [Manage collection templates by product inventory](./manage-collection-templates-by-product-inventory)
+* [Move out-of-stock products to the end of a collection](./move-out-of-stock-products-to-the-end-of-a-collection)
+* [Publish a certain collection, daily](./publish-a-certain-collection-daily)
+* [Rotate products through a featured collection](./rotate-products-through-a-featured-collection)
+* [Send an email alert if a new collection has no orders after x days](./send-an-email-alert-if-a-new-collection-has-no-orders-after-x-days)
+* [Send an email when a purchase is made from a certain collection](./send-an-email-when-a-purchase-is-made-from-a-certain-collection)
+* [Unpublish a certain collection, daily](./unpublish-a-certain-collection-daily)
+
+### Comments
+
+* [Sync order timeline comments to the customer note](./sync-order-timeline-comments-to-the-customer-note)
+
+### Compare at
+
+* [Auto-tag products that have a "compare at" price](./auto-tag-products-that-have-a-compare-at-price)
+
+### Costs
+
+* [Auto-tag products that are missing costs](./auto-tag-products-that-are-missing-costs)
+* [Report Toaster: Pirate Ship Integration](./report-toaster-pirateship-integration)
+* [Report Toaster: ShipStation Integration](./report-toaster-shipstation-integration)
+* [Send an email when a product's price goes below its cost](./send-an-email-when-a-products-price-goes-below-its-cost)
+
+### Customer Notes
+
+* [Auto-copy notes from customers to their orders](./auto-copy-notes-from-customers-to-their-orders)
+* [Auto-copy order notes to the customer's note](./auto-copy-order-notes-to-the-customers-note)
+* [Auto-tag new orders with a value from the customer note](./auto-tag-new-orders-with-a-value-from-the-customer-note)
+* [Monitor customer note for certain information](./monitor-customer-note-for-certain-information)
+* [Sync order timeline comments to the customer note](./sync-order-timeline-comments-to-the-customer-note)
+
+### Customers
+
+* [Add new customers to GetResponse](./add-new-customers-to-getresponse)
+* [Auto-add an order note for customers having a certain tag](./auto-add-an-order-note-for-customers-having-a-certain-tag)
+* [Auto-add an order note for returning customers](./auto-add-an-order-note-for-returning-customers)
+* [Auto-add phone numbers to unfulfilled orders, when the customer is updated](./auto-add-phone-numbers-to-unfulfilled-orders-when-the-customer-is-updated)
+* [Auto-copy customer metafields to new orders](./auto-copy-customer-metafields-to-new-orders)
+* [Auto-copy notes from customers to their orders](./auto-copy-notes-from-customers-to-their-orders)
+* [Auto-delete customers that are created without orders](./auto-delete-customers-that-are-created-without-orders)
+* [Auto-tag a customer's first order](./auto-tag-a-customers-first-order)
+* [Auto-tag customers based on discount codes used](./auto-tag-customers-based-on-discount-codes-used)
+* [Auto-tag customers based on email domain](./auto-tag-customers-by-email-domain)
+* [Auto-tag customers by order app](./auto-tag-customers-by-order-app)
+* [Auto-tag customers by purchased SKUs](./auto-tag-customers-by-purchased-skus)
+* [Auto-tag customers by sales channel](./auto-tag-customers-by-sales-channel)
+* [Auto-tag customers having a rolling minimum total spend](./auto-tag-customers-having-a-rolling-minimum-total-spend)
+* [Auto-tag customers that accept marketing](./auto-tag-customers-that-accept-marketing)
+* [Auto-tag customers when another tag is added](./auto-tag-customers-when-another-tag-is-added)
+* [Auto-tag customers when their order is paid](./auto-tag-customers-when-order-paid)
+* [Auto-tag customers when their order is tagged](./auto-tag-customers-when-their-order-is-tagged)
+* [Auto-tag customers when they purchase a matching product](./auto-tag-customers-upon-product-purchase)
+* [Auto-tag customers who purchase an item on sale](./auto-tag-customers-who-purchase-an-item-on-sale)
+* [Auto-tag customers with Locksmith passcodes used](./auto-tag-customers-with-locksmith-passcodes-used)
+* [Auto-tag customers with product tags from their order](./tag-customers-with-product-tags-from-their-order)
+* [Auto-tag customers with the location of their purchase](./auto-tag-customers-with-the-location-of-their-purchase)
+* [Auto-tag customers with vendors after ordering](./auto-tag-customers-with-vendors-after-ordering)
+* [Auto-tag customers with who have accounts](./auto-tag-customers-with-who-have-accounts)
+* [Auto-tag customers within a purchase range](./auto-tag-customers-within-a-purchase-range)
+* [Auto-tag new customers with the current date](./auto-tag-customers-with-the-current-date)
+* [Auto-tag new customers](./auto-tag-new-customers)
+* [Auto-tag new orders using the customer's tags](./auto-tag-orders-using-the-customers-tags)
+* [Auto-tag new orders with a value from the customer note](./auto-tag-new-orders-with-a-value-from-the-customer-note)
+* [Auto-tag orders based on customer account tags](./auto-tag-orders-based-on-customer-account-tags)
+* [Auto-tag orders with customer tags when new customer tags are added](./tag-orders-with-customer-tags-when-customer-is-tagged)
+* [Auto-untag customers when a certain product is refunded](./auto-untag-customers-when-a-certain-product-is-refunded)
+* [Auto-verify customer email addresses](./auto-verify-customer-email-addresses)
+* [Automatically send account invite to new customers](./automatically-send-account-invite-to-new-customers)
+* [Copy order and/or product tags to customers](./copy-order-tags-to-customers)
+* [Copy prefixed tags to metafields](./copy-prefixed-tags-to-metafields)
+* [Credit customers for sample orders](./credit-customers-for-sample-orders)
+* [Delete customer metafields in bulk](./delete-customer-metafields-in-bulk)
+* [Email a report of customers who haven't ordered in X days](./email-a-report-of-customers-who-havent-ordered-in-x-days)
+* [Email all customers who made a purchase](./email-customers-who-purchased-product)
+* [Email customer when their order is paid](./email-customer-when-order-paid)
+* [Email customers a unique discount code, two weeks after order fulfillment](./email-customers-a-unique-discount-code-two-weeks-after-order-fulfillment)
+* [Email customers after purchasing a certain product](./product-order-email)
+* [Email customers when created](./email-customers-when-created)
+* [Email customers when tagged](./email-customers-when-tagged)
+* [Email customers when their order is tagged](./email-customer-when-order-tagged)
+* [Email someone specific based on a new order's customer tags](./email-someone-specific-based-on-a-new-orders-customer-tags)
+* [Email the customer when tracking numbers are added to their order](./email-the-customer-when-tracking-numbers-are-added-to-their-order)
+* [Monitor customer note for certain information](./monitor-customer-note-for-certain-information)
+* [Record Judge.me customer review counts](./record-judge-me-customer-review-counts)
+* [Remind customers after x days about unpaid orders](./remind-customers-after-x-days-about-unpaid-orders)
+* [Remove a customer tag when another tag is added](./remove-a-customer-tag-when-another-tag-is-added)
+* [Schedule customer auto-tagging after a purchase](./schedule-customer-auto-tagging-after-a-purchase)
+* [Send a customer signup email](./customer-signup-email)
+* [Send a follow-up email to customers after purchasing from a certain vendor](./send-a-follow-up-email-to-customers-after-purchasing-from-a-certain-vendor)
+* [Send a welcome email to new customers, in their language](./send-a-welcome-email-to-new-customers-in-their-language)
+* [Send account invites to all customers in bulk](./send-account-invites-to-all-customers-in-bulk)
+* [Send an email alert when a customer changes state](./send-an-email-alert-when-a-customer-changes-state)
+* [Send an email to all customers](./send-an-email-to-all-customers)
+* [Send customers a reorder link X days after ordering](./send-customers-a-reorder-link-x-days-after-ordering)
+* [Send follow-up emails after sending a draft order invoice](./send-follow-up-emails-after-sending-a-draft-order-invoice)
+* [Send new customer signups to IFTTT](./send-new-customer-signups-to-ifttt)
+* [Send your customers reorder reminders](./send-your-customers-reorder-reminders)
+* [Sync an inverse customer tag](./sync-an-inverse-customer-tag)
+* [Tag and segment customers by days since last order](./tag-and-segment-customers-by-days-since-last-order)
+* [Tag customers by order tier](./tag-customers-by-order-tier)
+* [Tag customers in bulk by email address](./tag-customers-in-bulk-by-email-address)
+* [Tag customers on the anniversary of their first order](./tag-customers-on-the-anniversary-of-their-first-order)
+* [Tag customers when their last order is before/after x days ago](./tag-customers-when-their-last-order-is-before-after-x-days-ago)
+* [Temporarily enable tax-exempt status when a customer is tagged](./temporarily-enable-tax-exempt-status-when-a-customer-is-tagged)
+* [Update empty customer data from addresses](./update-empty-customer-data-from-addresses)
+
+### Delete
+
+* [Auto-delete customers that are created without orders](./auto-delete-customers-that-are-created-without-orders)
+* [Delete all products](./delete-all-products)
+* [Delete cancelled orders after 48 hours](./delete-cancelled-orders-after-48-hours)
+* [Delete draft orders older than 30 days](./delete-draft-orders-older-than-30-days)
+* [Delete draft orders](./delete-draft-orders)
+* [Delete the oldest x products from a specific collection](./delete-the-oldest-x-products-from-a-specific-collection)
+* [Delete variants having a metafield date that has passed](./delete-variants-having-a-metafield-date-that-has-passed)
+
+### Delivery
+
+* [Archive orders on delivery](./archive-orders-on-delivery)
+* [Auto-associate products with a delivery profile, by product tag](./auto-associate-products-with-a-delivery-profile-by-product-tag)
+* [Auto-associate variants with a delivery profile, by metafield value](./auto-associate-variants-with-a-delivery-profile-by-metafield-value)
+* [Send a staff notification email for each delivery](./send-a-staff-notification-email-for-each-delivery)
+* [Send an email alert when an incoming Canadian order has an unsupported FSA](./send-an-email-alert-when-an-incoming-canadian-order-has-an-unsupported-fsa)
+
+### Demonstration
+
+* [Demonstration: Auto-tag new orders, with scheduled reconciliation](./demonstration-auto-tag-new-orders-with-reconciliation)
+* [Demonstration: Fetch an external configuration file](./demonstration-fetch-an-external-configuration-file)
+* [Demonstration: Generate product sales report PDF with pie chart](./demonstration-generate-product-sales-report-pdf-with-pie-chart)
+* [Demonstration: Generating a file and uploading it to Shopify](./demonstration-generate-a-file-and-upload-to-shopify)
+* [Demonstration: Order editing](./demonstration-order-editing)
+* [Demonstration: Performing action runs in sequence](./demonstration-performing-action-runs-in-sequence)
+* [Demonstration: Shopify Flow integration](./demonstration-shopify-flow-integration)
+* [Demonstration: Web fonts in PDFs](./demonstration-web-fonts-in-pdfs)
+* [Demonstration: Write to a customer metafield](./demonstration-write-to-a-customer-metafield)
+
+### Discounts
+
+* [Activate a discount when ISS passes overhead](./activate-a-discount-when-iss-passes-overhead)
+* [Advanced: Scheduled Price Changes](./advanced-scheduled-price-changes)
+* [Auto-price products based on their compare-at prices](./auto-price-products-based-on-their-compare-at-prices)
+* [Auto-tag customers based on discount codes used](./auto-tag-customers-based-on-discount-codes-used)
+* [Auto-tag orders by discount code](./auto-tag-orders-by-discount-code)
+* [Email customers a unique discount code, two weeks after order fulfillment](./email-customers-a-unique-discount-code-two-weeks-after-order-fulfillment)
+* [Generate a discount code when a certain product is purchased](./generate-a-discount-code-when-a-certain-product-is-purchased)
+* [Generate a product discount when a voucher product is purchased](./generate-a-product-discount-when-a-voucher-product-is-purchased)
+* [Maintain discount percentage filters in variant metafields](./maintain-discount-percentage-filters-in-variant-metafields)
+* [Reissue single-use discount codes after order cancellation](./reissue-single-use-discount-codes-after-order-cancellation)
+
+### Download
+
+* [Download and email a file to a customer, when purchased](./download-and-email-a-file-to-a-customer-when-purchased)
+
+### Draft Orders
+
+* [Auto-add the draft order to a new order's attributes](./auto-add-the-draft-order-id-to-an-orders-attributes)
+* [Auto-complete new draft orders](./auto-complete-new-draft-orders)
+* [Auto-recurring draft orders](./auto-recurring-draft-orders)
+* [Auto-tag draft orders by originating staff member](./auto-tag-draft-orders-by-originating-staff-member)
+* [Auto-tag new draft orders](./auto-tag-new-draft-orders)
+* [Auto-tag orders created from drafts](./auto-tag-orders-created-from-drafts)
+* [Clean up draft orders](./clean-up-draft-orders)
+* [Copy draft order metafields to orders](./copy-draft-order-metafields-to-orders)
+* [Create a draft order from the cart](./create-a-draft-order-from-the-cart)
+* [Delete draft orders older than 30 days](./delete-draft-orders-older-than-30-days)
+* [Delete draft orders](./delete-draft-orders)
+* [Send follow-up emails after sending a draft order invoice](./send-follow-up-emails-after-sending-a-draft-order-invoice)
+
+### Email
+
+* [Abandoned checkout emails](./abandoned-checkout-emails)
+* [Ask for reviews a week after order fulfillment](./ask-for-reviews-a-week-after-order-fulfillment)
+* [Auto-invite customers after an order](./auto-invite-customers-after-an-order)
+* [Auto-invite customers when tagged](./auto-invite-customers-when-tagged)
+* [Auto-verify customer email addresses](./auto-verify-customer-email-addresses)
+* [Automatically send account invite to new customers](./automatically-send-account-invite-to-new-customers)
+* [Catalog update email](./catalog-update-email)
+* [Download and email a file to a customer, when purchased](./download-and-email-a-file-to-a-customer-when-purchased)
+* [Email a CSV export of orders](./email-a-csv-export-of-orders)
+* [Email a CSV export of products](./email-a-csv-export-of-products)
+* [Email a report of customers who haven't ordered in X days](./email-a-report-of-customers-who-havent-ordered-in-x-days)
+* [Email a report of pick-up orders for the next x days](./email-a-report-of-pick-up-orders-for-the-next-x-days)
+* [Email a summary of all products and quantities ordered](./email-a-summary-of-all-products-and-quantities-ordered)
+* [Email all customers who made a purchase](./email-customers-who-purchased-product)
+* [Email customer when their order is paid](./email-customer-when-order-paid)
+* [Email customers after purchasing a certain product](./product-order-email)
+* [Email customers when created](./email-customers-when-created)
+* [Email customers when tagged](./email-customers-when-tagged)
+* [Email customers when their order is tagged](./email-customer-when-order-tagged)
+* [Email someone specific based on a new order's customer tags](./email-someone-specific-based-on-a-new-orders-customer-tags)
+* [Email someone when a certain product is purchased](./email-someone-when-certain-product-purchased)
+* [Email someone when a certain variant is purchased](./email-when-variant-purchased)
+* [Email the customer when tracking numbers are added to their order](./email-the-customer-when-tracking-numbers-are-added-to-their-order)
+* [Email vendors when an order is tagged](./email-vendors-when-an-order-is-tagged)
+* [Email vendors when an order shipping address changes](./email-vendors-when-an-order-shipping-address-changes)
+* [Email vendors when their products are ordered](./email-vendors-when-their-products-are-ordered)
+* [Email your customers after a quiet period of no orders](./email-your-customers-after-a-quiet-period-of-no-orders)
+* [Forward incoming email to another address](./forward-incoming-email-to-another-address)
+* [Generate a simple product catalog PDF](./generate-a-simple-product-catalog-pdf)
+* [Get email alerts for FBA failures](./get-email-alerts-for-fba-failures)
+* [Get email alerts for out of stock products](./get-email-alerts-for-out-of-stock-products)
+* [Notify a team when a tagged product is ordered](./notify-a-team-when-a-tagged-product-is-ordered)
+* [Receive a nightly out-of-stock report](./receive-a-nightly-out-of-stock-report)
+* [Receive email alerts when inventory levels change](./receive-email-alerts-when-inventory-levels-change)
+* [Remind customers that their order is on the way](./remind-customers-that-their-order-is-on-the-way)
+* [Report Toaster: Deliver report PDF via email or Slack](./report-toaster-deliver-report-pdf-via-email-or-slack)
+* [Send a PDF invoice when an order is created](./send-a-pdf-invoice-when-an-order-is-created)
+* [Send a PDF when an order is sent to Mechanic](./send-a-pdf-when-an-order-is-sent-to-mechanic)
+* [Send a customer signup email](./customer-signup-email)
+* [Send a follow-up email after order cancellation](./send-a-follow-up-email-after-order-cancellation)
+* [Send a follow-up email to customers after purchasing from a certain vendor](./send-a-follow-up-email-to-customers-after-purchasing-from-a-certain-vendor)
+* [Send a new-order email to someone based on a cart attribute](./send-a-new-order-email-to-someone-based-on-a-cart-attribute)
+* [Send a staff notification email for each delivery](./send-a-staff-notification-email-for-each-delivery)
+* [Send a welcome email to new customers, in their language](./send-a-welcome-email-to-new-customers-in-their-language)
+* [Send an email alert if a new collection has no orders after x days](./send-an-email-alert-if-a-new-collection-has-no-orders-after-x-days)
+* [Send an email alert on fulfillment failure](./fulfillment-failure-email)
+* [Send an email alert when a customer changes state](./send-an-email-alert-when-a-customer-changes-state)
+* [Send an email alert when a customer places more than 2 orders in 24 hours](./send-an-email-alert-when-a-customer-places-more-than-2-orders-in-24-hours)
+* [Send an email alert when a fulfillment is cancelled](./send-an-email-alert-when-a-fulfillment-is-cancelled)
+* [Send an email alert when a variant hits 0 total inventory](./send-an-email-alert-when-a-variant-hits-0-total-inventory)
+* [Send an email alert when an incoming Canadian order has an unsupported FSA](./send-an-email-alert-when-an-incoming-canadian-order-has-an-unsupported-fsa)
+* [Send an email to all customers](./send-an-email-to-all-customers)
+* [Send an email when a product's price goes below its cost](./send-an-email-when-a-products-price-goes-below-its-cost)
+* [Send an email when a purchase is made from a certain collection](./send-an-email-when-a-purchase-is-made-from-a-certain-collection)
+* [Send an email when a specific product is shipped](./send-an-email-when-a-specific-product-is-shipped)
+* [Send customers a reorder link X days after ordering](./send-customers-a-reorder-link-x-days-after-ordering)
+* [Send email when an order comes in](./send-email-when-an-order-comes-in)
+* [Send email when an order is tagged](./send-email-when-an-order-is-tagged)
+* [Send follow-up emails after sending a draft order invoice](./send-follow-up-emails-after-sending-a-draft-order-invoice)
+* [Send recurring reminders about unpaid orders](./unpaid-order-reminders)
+* [Send your customers reorder reminders](./send-your-customers-reorder-reminders)
+* [Tag customers in bulk by email address](./tag-customers-in-bulk-by-email-address)
+* [Trigger order emails with a tag](./trigger-order-emails-with-a-tag)
+
+### Error
+
+* [Error reporter](./error-reporter)
+
+### Export
+
+* [Backup inventory to SFTP in Shopify CSV format](./backup-scheduled-inventory-exports-in-shopifys-csv-format)
+* [Email a CSV export of orders](./email-a-csv-export-of-orders)
+* [Email a CSV export of products](./email-a-csv-export-of-products)
+* [Export a CSV of order shipping addresses](./export-a-csv-of-order-shipping-addresses)
+* [Export all products to SFTP, as a Shopify-friendly CSV](./export-all-products-to-sftp-as-a-shopify-friendly-csv)
+
+### External API
+
+* [Add new customers to GetResponse](./add-new-customers-to-getresponse)
+* [Demonstration: Fetch an external configuration file](./demonstration-fetch-an-external-configuration-file)
+* [Import PayPal transactions as Shopify orders](./import-paypal-transactions-as-shopify-orders)
+* [Report Toaster: Pirate Ship Integration](./report-toaster-pirateship-integration)
+* [Report Toaster: ShipStation Integration](./report-toaster-shipstation-integration)
+* [Send an event to Klaviyo when a fulfillment is delayed](./send-an-event-to-klaviyo-when-a-fulfillment-is-delayed)
+
+### FTP
+
+* [Backup inventory to SFTP in Shopify CSV format](./backup-scheduled-inventory-exports-in-shopifys-csv-format)
+* [Export all products to SFTP, as a Shopify-friendly CSV](./export-all-products-to-sftp-as-a-shopify-friendly-csv)
+
+### Featured
+
+* [Rotate products through a featured collection](./rotate-products-through-a-featured-collection)
+
+### Feeds
+
+* [Create a product inventory CSV feed](./create-a-product-inventory-feed)
+
+### Files
+
+* [Demonstration: Generating a file and uploading it to Shopify](./demonstration-generate-a-file-and-upload-to-shopify)
+* [Demonstration: Web fonts in PDFs](./demonstration-web-fonts-in-pdfs)
+* [Download and email a file to a customer, when purchased](./download-and-email-a-file-to-a-customer-when-purchased)
+* [Generate a simple product catalog PDF](./generate-a-simple-product-catalog-pdf)
+
+### Financial Status
+
+* [Auto-tag orders by financial status](./auto-tag-orders-by-financial-status)
+
+### Fulfillment
+
+* [Add fulfillment tracking when an order is tagged](./add-fulfillment-tracking-when-an-order-is-tagged)
+* [Add note to new orders with their fulfillment locations](./note-new-orders-with-their-fulfillment-locations)
+* [Archive orders when fulfilled](./archive-orders-when-fulfilled)
+* [Ask for reviews a week after order fulfillment](./ask-for-reviews-a-week-after-order-fulfillment)
+* [Auto-add phone numbers to unfulfilled orders, when the customer is updated](./auto-add-phone-numbers-to-unfulfilled-orders-when-the-customer-is-updated)
+* [Auto-archive orders after fulfillment](./auto-archive-orders-after-fulfillment)
+* [Auto-cancel fulfillments when an order is tagged](./auto-cancel-fulfillments-when-an-order-is-tagged)
+* [Auto-fulfill items that don't require shipping](./auto-fulfill-items-that-dont-require-shipping)
+* [Auto-fulfill orders when tagged](./auto-fulfill-orders-when-tagged)
+* [Auto-prefix tracking numbers for each new fulfillment](./auto-prefix-tracking-numbers-for-each-new-fulfillment)
+* [Auto-tag fulfilled orders by carrier](./auto-tag-fulfilled-orders-by-carrier)
+* [Auto-tag fulfilled orders with their carriers](./auto-tag-fulfilled-orders-with-their-carriers)
+* [Auto-tag new orders with their fulfillment locations](./auto-tag-new-orders-with-their-fulfillment-locations)
+* [Cancel fulfillments when an order is fully refunded](./cancel-fulfillments-when-an-order-is-fully-refunded)
+* [Capture order payment upon fulfillment](./capture-order-payment-upon-fulfillment)
+* [Flag orders that aren't fulfilled after several days](./flag-orders-that-arent-fulfilled-after-two-days)
+* [Get email alerts for FBA failures](./get-email-alerts-for-fba-failures)
+* [Manage fulfillment shipment status using order tags](./manage-fulfillment-status-using-order-tags)
+* [Partially auto-capture payments as orders are fulfilled](./partially-auto-capture-payments-as-orders-are-fulfilled)
+* [Send an email alert on fulfillment failure](./fulfillment-failure-email)
+* [Send an email alert when a fulfillment is cancelled](./send-an-email-alert-when-a-fulfillment-is-cancelled)
+* [Send an event to Klaviyo when a fulfillment is delayed](./send-an-event-to-klaviyo-when-a-fulfillment-is-delayed)
+* [Set a default tracking number for new fulfillments](./set-a-default-tracking-number-for-new-fulfillments)
+
+### IFTTT
+
+* [Send new customer signups to IFTTT](./send-new-customer-signups-to-ifttt)
+
+### Images
+
+* [Tag products with no images](./tag-products-with-no-images)
+
+### Import
+
+* [Import PayPal transactions as Shopify orders](./import-paypal-transactions-as-shopify-orders)
+
+### In stock
+
+* [Add Option Name as a Variant Metafield for In Stock Variants](./add-option-names-as-variant-metafields-for-in-stock-variants)
+* [Tag products as in- or out-of-stock, by location ID](./tag-products-as-in-or-out-of-stock-by-location-id)
+* [Tag products as in- or out-of-stock](./tag-products-as-in-or-out-of-stock)
+
+### Integration
+
+* [Bulk trigger Shopify Flow with historical data](./bulk-trigger-shopify-flow-with-historical-data)
+* [Demonstration: Shopify Flow integration](./demonstration-shopify-flow-integration)
+* [Report Toaster: Pirate Ship Integration](./report-toaster-pirateship-integration)
+* [Report Toaster: ShipStation Integration](./report-toaster-shipstation-integration)
+* [Trigger Shopify Flow with a time delay](./trigger-shopify-flow-with-a-time-delay)
+
+### Inventory
+
+* [Auto-connect new products to all locations](./auto-connect-new-products-to-all-locations)
+* [Auto-sort collections by inventory levels](./auto-sort-collections-by-inventory-levels)
+* [Auto-tag out-of-stock products](./auto-tag-out-of-stock-products)
+* [Auto-tag products with incoming inventory](./auto-tag-products-with-incoming-inventory)
+* [Create a product inventory CSV feed](./create-a-product-inventory-feed)
+* [Email a summary of all products and quantities ordered](./email-a-summary-of-all-products-and-quantities-ordered)
+* [Keep inventory levels in sync within products](./keep-inventory-levels-in-sync-within-products)
+* [Maintain inventory for a product bundle](./maintain-inventory-for-a-product-bundle)
+* [Manage collection templates by product inventory](./manage-collection-templates-by-product-inventory)
+* [Publish back-in-stock products](./publish-back-in-stock-products)
+* [Receive a nightly out-of-stock report](./receive-a-nightly-out-of-stock-report)
+* [Receive email alerts when inventory levels change](./receive-email-alerts-when-inventory-levels-change)
+* [Reset all inventory levels to a single level, in bulk](./reset-all-inventory-levels-to-a-single-level-in-bulk)
+* [Reset inventory levels daily](./reset-inventory-levels-daily)
+* [Reset inventory levels when they get too low](./reset-inventory-levels-when-they-get-too-low)
+* [Reset negative inventory levels to zero in bulk](./reset-negative-inventory-levels-to-zero-in-bulk)
+* [Send an email alert when a variant hits 0 total inventory](./send-an-email-alert-when-a-variant-hits-0-total-inventory)
+* [Sync inventory across a product type](./sync-inventory-across-a-product-type)
+* [Sync inventory across product variants](./sync-inventory-across-product-variants)
+* [Sync inventory for shared SKUs](./sync-inventory-for-shared-skus)
+* [Sync inventory levels to variant metafields](./sync-inventory-levels-to-variant-metafields)
+* [Sync variant inventory within a product by pack size](./sync-variant-inventory-within-a-product-by-pack-size)
+* [Tag products as in- or out-of-stock](./tag-products-as-in-or-out-of-stock)
+* [Unpublish products that have been out of stock for x days](./unpublish-products-that-have-been-out-of-stock-for-x-days)
+
+### Invite
+
+* [Auto-invite customers after an order](./auto-invite-customers-after-an-order)
+* [Auto-invite customers when tagged](./auto-invite-customers-when-tagged)
+* [Automatically send account invite to new customers](./automatically-send-account-invite-to-new-customers)
+* [Send account invites to all customers in bulk](./send-account-invites-to-all-customers-in-bulk)
+
+### Invoice
+
+* [Send a PDF invoice when an order is created](./send-a-pdf-invoice-when-an-order-is-created)
+* [Send follow-up emails after sending a draft order invoice](./send-follow-up-emails-after-sending-a-draft-order-invoice)
+
+### Judge.me
+
+* [Record Judge.me customer review counts](./record-judge-me-customer-review-counts)
+
+### Kount
+
+* [Auto-capture order payments based on Kount risk assessments](./auto-capture-order-payments-based-on-kount-risk-assessments)
+
+### Line Item Properties
+
+* [Auto-tag orders with their line item properties](./auto-tag-orders-with-their-line-item-properties)
+
+### Localization
+
+* [Send a welcome email to new customers, in their language](./send-a-welcome-email-to-new-customers-in-their-language)
+
+### Location
+
+* [Add note to new orders with their fulfillment locations](./note-new-orders-with-their-fulfillment-locations)
+* [Auto-tag customers with the location of their purchase](./auto-tag-customers-with-the-location-of-their-purchase)
+* [Auto-tag new orders with their fulfillment locations](./auto-tag-new-orders-with-their-fulfillment-locations)
+* [Tag products as in- or out-of-stock, by location ID](./tag-products-as-in-or-out-of-stock-by-location-id)
+
+### Locksmith
+
+* [Auto-tag customers with Locksmith passcodes used](./auto-tag-customers-with-locksmith-passcodes-used)
+* [Tag online orders by ?ls= Locksmith secret link used](./tag-orders-by-locksmith-secret-link)
+
+### Low Stock
+
+* [Receive a nightly out-of-stock report](./receive-a-nightly-out-of-stock-report)
+* [Reset inventory levels when they get too low](./reset-inventory-levels-when-they-get-too-low)
+
+### Loyalty
+
+* [Auto-tag customers within a purchase range](./auto-tag-customers-within-a-purchase-range)
+* [Email all customers who made a purchase](./email-customers-who-purchased-product)
+* [Email your customers after a quiet period of no orders](./email-your-customers-after-a-quiet-period-of-no-orders)
+* [Send your customers reorder reminders](./send-your-customers-reorder-reminders)
+* [Tag and segment customers by days since last order](./tag-and-segment-customers-by-days-since-last-order)
+* [Tag customers by order tier](./tag-customers-by-order-tier)
+* [Tag customers when their last order is before/after x days ago](./tag-customers-when-their-last-order-is-before-after-x-days-ago)
+
+### Marketing
+
+* [Auto-tag customers that accept marketing](./auto-tag-customers-that-accept-marketing)
+* [Auto-tag orders with UTM parameters](./auto-tag-orders-with-utm-parameters)
+* [Generate a discount code when a certain product is purchased](./generate-a-discount-code-when-a-certain-product-is-purchased)
+* [Send customers a reorder link X days after ordering](./send-customers-a-reorder-link-x-days-after-ordering)
+
+### Markets
+
+* [Unpublish products from markets when locations are out of stock](./unpublish-products-from-markets-when-locations-are-out-of-stock)
+
+### Max Orders
+
+* [Accept a maximum number of orders per day](./accept-a-maximum-number-of-orders-per-day)
+* [Accept a maximum number of orders per hour](./accept-a-maximum-number-of-orders-per-hour)
+
+### Membership
+
+* [Manage annual memberships based on order minimums](./manage-annual-memberships-based-on-order-minimums)
+* [Manage tagging for a time-limited membership product](./manage-tagging-for-a-time-limited-membership-product)
+
+### Metafields
+
+* [Add Option Name as a Variant Metafield for In Stock Variants](./add-option-names-as-variant-metafields-for-in-stock-variants)
+* [Auto-associate variants with a delivery profile, by metafield value](./auto-associate-variants-with-a-delivery-profile-by-metafield-value)
+* [Auto-copy customer metafields to new orders](./auto-copy-customer-metafields-to-new-orders)
+* [Auto-tag new products by "back in stock" age](./auto-tag-new-products-by-back-in-stock-age)
+* [Copy draft order metafields to orders](./copy-draft-order-metafields-to-orders)
+* [Copy prefixed tags to metafields](./copy-prefixed-tags-to-metafields)
+* [Copy product metafields to each product's tags](./copy-product-metafields-to-each-products-tags)
+* [Delete customer metafields in bulk](./delete-customer-metafields-in-bulk)
+* [Delete product or product variant metafields in bulk](./delete-product-or-product-variant-metafields-in-bulk)
+* [Delete variants having a metafield date that has passed](./delete-variants-having-a-metafield-date-that-has-passed)
+* [Demonstration: Write to a customer metafield](./demonstration-write-to-a-customer-metafield)
+* [Maintain collections by product metafield values](./maintain-collections-by-product-metafield-values)
+* [Maintain discount percentage filters in variant metafields](./maintain-discount-percentage-filters-in-variant-metafields)
+* [Make products unavailable, after the date/time stored in product metafields](./make-products-unavailable-after-the-date-time-stored-in-product-metafields)
+* [Send an email when a product's price goes below its cost](./send-an-email-when-a-products-price-goes-below-its-cost)
+* [Set product or variant metafields values in bulk](./set-product-or-variant-metafields-in-bulk)
+* [Sync inventory levels to variant metafields](./sync-inventory-levels-to-variant-metafields)
+* [Track incoming donations in a store metafield](./track-incoming-donations-in-a-store-metafield)
+
+### Multi-Location
+
+* [Auto-connect new products to all locations](./auto-connect-new-products-to-all-locations)
+* [Tag products as in- or out-of-stock, by location ID](./tag-products-as-in-or-out-of-stock-by-location-id)
+
+### Online Store 2.0
+
+* [Add Option Name as a Variant Metafield for In Stock Variants](./add-option-names-as-variant-metafields-for-in-stock-variants)
+* [Copy prefixed tags to metafields](./copy-prefixed-tags-to-metafields)
+* [Maintain discount percentage filters in variant metafields](./maintain-discount-percentage-filters-in-variant-metafields)
+
+### Order Attributes
+
+* [Auto-add default custom attributes to new orders](./auto-add-default-custom-attributes-to-new-orders)
+* [Auto-add the draft order to a new order's attributes](./auto-add-the-draft-order-id-to-an-orders-attributes)
+* [Auto-copy customer metafields to new orders](./auto-copy-customer-metafields-to-new-orders)
+* [Auto-remove attributes on new orders after X minutes](./auto-remove-attributes-on-new-orders-after-x-minutes)
+* [Auto-tag new online orders by web browser](./auto-tag-new-online-orders-by-web-browser)
+
+### Order Editing
+
+* [Auto-add bundle components to orders, post-purchase](./auto-add-bundle-components-to-orders-post-purchase)
+* [Demonstration: Order editing](./demonstration-order-editing)
+
+### Order Note
+
+* [Auto-add a note for new orders having a certain tag](./auto-add-order-note-for-new-tagged-orders)
+* [Auto-add an order note for customers having a certain tag](./auto-add-an-order-note-for-customers-having-a-certain-tag)
+* [Auto-add an order note for returning customers](./auto-add-an-order-note-for-returning-customers)
+* [Auto-copy notes from customers to their orders](./auto-copy-notes-from-customers-to-their-orders)
+* [Auto-copy order notes to the customer's note](./auto-copy-order-notes-to-the-customers-note)
+* [Temporarily add an order note](./temporarily-add-an-order-note)
+
+### Orders
+
+* [Accept a maximum number of orders per day](./accept-a-maximum-number-of-orders-per-day)
+* [Accept a maximum number of orders per hour](./accept-a-maximum-number-of-orders-per-hour)
+* [Add note to new orders with their fulfillment locations](./note-new-orders-with-their-fulfillment-locations)
+* [Archive free orders on fulfillment](./archive-free-orders-on-fulfillment)
+* [Archive orders on delivery](./archive-orders-on-delivery)
+* [Archive orders when fulfilled](./archive-orders-when-fulfilled)
+* [Archive orders when tagged](./archive-orders-when-tagged)
+* [Ask for reviews a week after order fulfillment](./ask-for-reviews-a-week-after-order-fulfillment)
+* [Auto-add a note for new orders having a certain tag](./auto-add-order-note-for-new-tagged-orders)
+* [Auto-add an order note for customers having a certain tag](./auto-add-an-order-note-for-customers-having-a-certain-tag)
+* [Auto-add bundle components to orders, post-purchase](./auto-add-bundle-components-to-orders-post-purchase)
+* [Auto-add default custom attributes to new orders](./auto-add-default-custom-attributes-to-new-orders)
+* [Auto-archive orders after fulfillment](./auto-archive-orders-after-fulfillment)
+* [Auto-cancel orders with too many of a certain SKU](./auto-cancel-orders-with-too-many-of-a-certain-sku)
+* [Auto-capture payments when an order is created](./auto-capture-payments-when-an-order-is-created)
+* [Auto-copy customer metafields to new orders](./auto-copy-customer-metafields-to-new-orders)
+* [Auto-delete customers that are created without orders](./auto-delete-customers-that-are-created-without-orders)
+* [Auto-fulfill items that don't require shipping](./auto-fulfill-items-that-dont-require-shipping)
+* [Auto-fulfill orders when tagged](./auto-fulfill-orders-when-tagged)
+* [Auto-invite customers after an order](./auto-invite-customers-after-an-order)
+* [Auto-pay orders from customers with a certain tag](./auto-pay-orders-from-customers-with-a-certain-tag)
+* [Auto-pay orders having a certain tag](./auto-pay-orders-having-a-certain-tag)
+* [Auto-remove attributes on new orders after X minutes](./auto-remove-attributes-on-new-orders-after-x-minutes)
+* [Auto-tag a customer's first order](./auto-tag-a-customers-first-order)
+* [Auto-tag cancelled orders](./auto-tag-cancelled-orders)
+* [Auto-tag customers by order app](./auto-tag-customers-by-order-app)
+* [Auto-tag customers when their order is paid](./auto-tag-customers-when-order-paid)
+* [Auto-tag customers when their order is tagged](./auto-tag-customers-when-their-order-is-tagged)
+* [Auto-tag customers when they purchase a matching product](./auto-tag-customers-upon-product-purchase)
+* [Auto-tag customers with the location of their purchase](./auto-tag-customers-with-the-location-of-their-purchase)
+* [Auto-tag fulfilled orders by carrier](./auto-tag-fulfilled-orders-by-carrier)
+* [Auto-tag fulfilled orders with their carriers](./auto-tag-fulfilled-orders-with-their-carriers)
+* [Auto-tag new orders based on payment method](./auto-tag-new-orders-based-on-payment-method)
+* [Auto-tag new orders by staff member](./auto-tag-new-orders-by-staff-member)
+* [Auto-tag new orders using Liquid](./auto-tag-new-orders-using-liquid)
+* [Auto-tag new orders using the customer's tags](./auto-tag-orders-using-the-customers-tags)
+* [Auto-tag new orders with a value from the customer note](./auto-tag-new-orders-with-a-value-from-the-customer-note)
+* [Auto-tag new orders with product SKUs](./auto-tag-new-orders-with-product-skus)
+* [Auto-tag new orders with their fulfillment locations](./auto-tag-new-orders-with-their-fulfillment-locations)
+* [Auto-tag new orders](./auto-tag-new-orders)
+* [Auto-tag open orders from the same customer with the same shipping address](./auto-tag-open-orders-from-same-customer-and-shipping-address)
+* [Auto-tag orders based on cart attributes](./auto-tag-orders-based-on-cart-attributes)
+* [Auto-tag orders based on customer account tags](./auto-tag-orders-based-on-customer-account-tags)
+* [Auto-tag orders based on shipping method](./auto-tag-orders-based-on-shipping-method)
+* [Auto-tag orders by app](./auto-tag-orders-by-app)
+* [Auto-tag orders by discount code](./auto-tag-orders-by-discount-code)
+* [Auto-tag orders by financial status](./auto-tag-orders-by-financial-status)
+* [Auto-tag orders by originating staff member](./auto-tag-orders-by-originating-staff-member)
+* [Auto-tag orders by product collections](./auto-tag-orders-by-product-collections)
+* [Auto-tag orders by sales channel](./auto-tag-orders-by-sales-channel)
+* [Auto-tag orders by shipping address city](./auto-tag-orders-by-shipping-address-city)
+* [Auto-tag orders by shipping address country](./auto-tag-orders-by-shipping-address-country)
+* [Auto-tag orders by their risk level](./auto-tag-orders-by-their-risk-level)
+* [Auto-tag orders created from drafts](./auto-tag-orders-created-from-drafts)
+* [Auto-tag orders from recurring client IP addresses](./auto-tag-orders-from-recurring-client-ip-addresses)
+* [Auto-tag orders that are ready to ship](./auto-tag-orders-that-are-ready-to-ship)
+* [Auto-tag orders that contain a matching product](./auto-tag-orders-that-contain-a-matching-product)
+* [Auto-tag orders that contain an out of stock item](./auto-tag-orders-that-contain-an-out-of-stock-item)
+* [Auto-tag orders that contain bundles](./auto-tag-orders-that-contain-bundles)
+* [Auto-tag orders that contain subscription products](./auto-tag-orders-that-contain-subscription-products)
+* [Auto-tag orders that do not have a certain tag](./auto-tag-orders-that-do-not-have-a-certain-tag)
+* [Auto-tag orders using product tags](./auto-tag-orders-using-product-tags)
+* [Auto-tag orders when another tag is added](./auto-tag-orders-when-another-tag-is-added)
+* [Auto-tag orders when paid](./auto-tag-orders-when-paid)
+* [Auto-tag orders with UTM parameters](./auto-tag-orders-with-utm-parameters)
+* [Auto-tag orders with a cart attribute](./auto-tag-orders-with-a-cart-attribute)
+* [Auto-tag orders with chargeback or inquiry activity](./auto-tag-orders-with-chargeback-or-inquiry-activity)
+* [Auto-tag orders with customer tags when new customer tags are added](./tag-orders-with-customer-tags-when-customer-is-tagged)
+* [Auto-tag orders with product tags](./auto-tag-orders-with-product-tags)
+* [Auto-tag orders with product vendors](./auto-tag-orders-with-product-vendors)
+* [Auto-tag orders with their line item properties](./auto-tag-orders-with-their-line-item-properties)
+* [Auto-tag orders with their tracking numbers](./auto-tag-orders-with-their-tracking-numbers)
+* [Automatically cancel high-risk orders](./automatically-cancel-high-risk-orders)
+* [Automatically cancel orders with certain risk indicators](./automatically-cancel-orders-with-certain-risk-indicators)
+* [Bulk capture orders by order number](./bulk-capture-by-order-number)
+* [Calculate total quantities purchased by SKU](./calculate-total-quantities-purchased-by-sku)
+* [Cancel and close unpaid orders after x hours/days](./cancel-and-close-unpaid-orders-after-two-days)
+* [Cancel fulfillments when an order is fully refunded](./cancel-fulfillments-when-an-order-is-fully-refunded)
+* [Clean up draft orders](./clean-up-draft-orders)
+* [Copy draft order metafields to orders](./copy-draft-order-metafields-to-orders)
+* [Copy prefixed tags to metafields](./copy-prefixed-tags-to-metafields)
+* [Credit customers for sample orders](./credit-customers-for-sample-orders)
+* [Delete cancelled orders after 48 hours](./delete-cancelled-orders-after-48-hours)
+* [Demonstration: Auto-tag new orders, with scheduled reconciliation](./demonstration-auto-tag-new-orders-with-reconciliation)
+* [Demonstration: Order editing](./demonstration-order-editing)
+* [Download and email a file to a customer, when purchased](./download-and-email-a-file-to-a-customer-when-purchased)
+* [Email a CSV export of orders](./email-a-csv-export-of-orders)
+* [Email a report of pick-up orders for the next x days](./email-a-report-of-pick-up-orders-for-the-next-x-days)
+* [Email customer when their order is paid](./email-customer-when-order-paid)
+* [Email customers after purchasing a certain product](./product-order-email)
+* [Email customers when their order is tagged](./email-customer-when-order-tagged)
+* [Email someone when a certain product is purchased](./email-someone-when-certain-product-purchased)
+* [Email someone when a certain variant is purchased](./email-when-variant-purchased)
+* [Email the customer when tracking numbers are added to their order](./email-the-customer-when-tracking-numbers-are-added-to-their-order)
+* [Email vendors when an order is tagged](./email-vendors-when-an-order-is-tagged)
+* [Email vendors when their products are ordered](./email-vendors-when-their-products-are-ordered)
+* [Flag orders that aren't fulfilled after several days](./flag-orders-that-arent-fulfilled-after-two-days)
+* [Import PayPal transactions as Shopify orders](./import-paypal-transactions-as-shopify-orders)
+* [Maintain a tag for orders processed today](./maintain-a-tag-for-orders-processed-today)
+* [Manage annual memberships based on order minimums](./manage-annual-memberships-based-on-order-minimums)
+* [Manage fulfillment shipment status using order tags](./manage-fulfillment-status-using-order-tags)
+* [Notify a team when a tagged product is ordered](./notify-a-team-when-a-tagged-product-is-ordered)
+* [Partially auto-capture payments as orders are fulfilled](./partially-auto-capture-payments-as-orders-are-fulfilled)
+* [Reissue single-use discount codes after order cancellation](./reissue-single-use-discount-codes-after-order-cancellation)
+* [Remove an order tag when another tag is added](./remove-a-order-tag-when-another-tag-is-added)
+* [Schedule customer auto-tagging after a purchase](./schedule-customer-auto-tagging-after-a-purchase)
+* [Send a PDF invoice when an order is created](./send-a-pdf-invoice-when-an-order-is-created)
+* [Send a follow-up email after order cancellation](./send-a-follow-up-email-after-order-cancellation)
+* [Send a new-order email to someone based on a cart attribute](./send-a-new-order-email-to-someone-based-on-a-cart-attribute)
+* [Send an email when a purchase is made from a certain collection](./send-an-email-when-a-purchase-is-made-from-a-certain-collection)
+* [Send email when an order comes in](./send-email-when-an-order-comes-in)
+* [Send email when an order is tagged](./send-email-when-an-order-is-tagged)
+* [Send recurring reminders about unpaid orders](./unpaid-order-reminders)
+* [Sync an inverse order tag](./sync-an-inverse-order-tag)
+* [Sync order timeline comments to the customer note](./sync-order-timeline-comments-to-the-customer-note)
+* [Tag online orders by ?ls= Locksmith secret link used](./tag-orders-by-locksmith-secret-link)
+* [Tag online orders by their ?ref= referral codes](./tag-orders-by-url-referrer)
+* [Tag orders in bulk by order name](./tag-orders-in-bulk-by-order-name)
+* [Tag orders that have at least x of a certain product](./tag-orders-that-have-at-least-x-of-a-certain-product)
+* [Trigger order emails with a tag](./trigger-order-emails-with-a-tag)
+* [Untag orders when paid](./untag-orders-when-paid)
+
+### Out of Stock
+
+* [Auto-tag orders that contain an out of stock item](./auto-tag-orders-that-contain-an-out-of-stock-item)
+* [Auto-tag out-of-stock products](./auto-tag-out-of-stock-products)
+* [Get email alerts for out of stock products](./get-email-alerts-for-out-of-stock-products)
+* [Hide out-of-stock products](./hide-out-of-stock-products)
+* [Move out-of-stock products to the end of a collection](./move-out-of-stock-products-to-the-end-of-a-collection)
+* [Send an email alert when a variant hits 0 total inventory](./send-an-email-alert-when-a-variant-hits-0-total-inventory)
+* [Tag products as in- or out-of-stock, by location ID](./tag-products-as-in-or-out-of-stock-by-location-id)
+* [Tag products as in- or out-of-stock](./tag-products-as-in-or-out-of-stock)
+* [Unpublish products from markets when locations are out of stock](./unpublish-products-from-markets-when-locations-are-out-of-stock)
+
+### PDF
+
+* [Demonstration: Generate product sales report PDF with pie chart](./demonstration-generate-product-sales-report-pdf-with-pie-chart)
+* [Demonstration: Generating a file and uploading it to Shopify](./demonstration-generate-a-file-and-upload-to-shopify)
+* [Demonstration: Web fonts in PDFs](./demonstration-web-fonts-in-pdfs)
+* [Generate a simple product catalog PDF](./generate-a-simple-product-catalog-pdf)
+* [Report Toaster: Deliver report PDF via email or Slack](./report-toaster-deliver-report-pdf-via-email-or-slack)
+* [Send a PDF invoice when an order is created](./send-a-pdf-invoice-when-an-order-is-created)
+* [Send a PDF when an order is sent to Mechanic](./send-a-pdf-when-an-order-is-sent-to-mechanic)
+
+### Payment
+
+* [Auto-capture order payment after x days](./auto-capture-order-payment-after-x-days)
+* [Auto-capture order payment based on shipping method](./auto-capture-order-payment-based-on-shipping-method)
+* [Auto-capture order payments based on Kount risk assessments](./auto-capture-order-payments-based-on-kount-risk-assessments)
+* [Auto-capture payments when an order is created](./auto-capture-payments-when-an-order-is-created)
+* [Auto-complete new draft orders](./auto-complete-new-draft-orders)
+* [Auto-pay orders from customers with a certain tag](./auto-pay-orders-from-customers-with-a-certain-tag)
+* [Auto-pay orders having a certain tag](./auto-pay-orders-having-a-certain-tag)
+* [Auto-tag customers when their order is paid](./auto-tag-customers-when-order-paid)
+* [Auto-tag new orders based on payment method](./auto-tag-new-orders-based-on-payment-method)
+* [Capture all authorized payments](./capture-all-authorized-payments)
+* [Capture order payment upon fulfillment](./capture-order-payment-upon-fulfillment)
+* [Email customer when their order is paid](./email-customer-when-order-paid)
+* [Partially auto-capture payments as orders are fulfilled](./partially-auto-capture-payments-as-orders-are-fulfilled)
+* [Untag orders when paid](./untag-orders-when-paid)
+
+### Pick-up
+
+* [Email a report of pick-up orders for the next x days](./email-a-report-of-pick-up-orders-for-the-next-x-days)
+
+### Price
+
+* [Advanced: Scheduled Price Changes](./advanced-scheduled-price-changes)
+* [Auto-price products based on their compare-at prices](./auto-price-products-based-on-their-compare-at-prices)
+* [Maintain discount percentage filters in variant metafields](./maintain-discount-percentage-filters-in-variant-metafields)
+* [Raise the price of a product after every sale](./raise-the-price-of-a-product-after-every-sale)
+* [Send an email when a product's price goes below its cost](./send-an-email-when-a-products-price-goes-below-its-cost)
+* [Tag products by their price ranges](./tag-products-by-their-price-ranges)
+
+### Products
+
+* [Add all products to a certain sales channel](./add-all-products-to-a-certain-sales-channel)
+* [Advanced: Scheduled Price Changes](./advanced-scheduled-price-changes)
+* [Auto publish products by tag](./auto-publish-products-by-tag)
+* [Auto-add products to a custom collection when tagged](./auto-add-products-to-a-custom-collection-when-tagged)
+* [Auto-associate products with a delivery profile, by product tag](./auto-associate-products-with-a-delivery-profile-by-product-tag)
+* [Auto-connect new products to all locations](./auto-connect-new-products-to-all-locations)
+* [Auto-create collections by product type or vendor](./auto-create-collections-by-product-type-or-vendor)
+* [Auto-price products based on their compare-at prices](./auto-price-products-based-on-their-compare-at-prices)
+* [Auto-publish new products](./auto-publish-new-products)
+* [Auto-publish products tagged with the current day](./auto-publish-products-tagged-with-the-current-day)
+* [Auto-sort collections by product properties](./auto-sort-collections-by-product-properties)
+* [Auto-tag customers when they purchase a matching product](./auto-tag-customers-upon-product-purchase)
+* [Auto-tag customers who purchase an item on sale](./auto-tag-customers-who-purchase-an-item-on-sale)
+* [Auto-tag customers with product tags from their order](./tag-customers-with-product-tags-from-their-order)
+* [Auto-tag new products by "back in stock" age](./auto-tag-new-products-by-back-in-stock-age)
+* [Auto-tag orders by product collections](./auto-tag-orders-by-product-collections)
+* [Auto-tag orders that contain a matching product](./auto-tag-orders-that-contain-a-matching-product)
+* [Auto-tag orders that contain subscription products](./auto-tag-orders-that-contain-subscription-products)
+* [Auto-tag orders using product tags](./auto-tag-orders-using-product-tags)
+* [Auto-tag orders with product tags](./auto-tag-orders-with-product-tags)
+* [Auto-tag orders with product vendors](./auto-tag-orders-with-product-vendors)
+* [Auto-tag out-of-stock products](./auto-tag-out-of-stock-products)
+* [Auto-tag products based on their product type](./auto-tag-products-based-on-their-product-type)
+* [Auto-tag products based on their publishing status](./auto-tag-products-based-on-their-publishing-status)
+* [Auto-tag products by age](./auto-tag-new-products-by-age)
+* [Auto-tag products by largest available size](./auto-tag-products-by-largest-available-size)
+* [Auto-tag products by their options](./auto-tag-products-by-their-options)
+* [Auto-tag products by their publish date](./auto-tag-products-by-their-publish-date)
+* [Auto-tag products in a manual collection](./auto-tag-products-in-a-manual-collection)
+* [Auto-tag products that are missing costs](./auto-tag-products-that-are-missing-costs)
+* [Auto-tag products that have a "compare at" price](./auto-tag-products-that-have-a-compare-at-price)
+* [Auto-tag products that meet a sales threshold](./auto-tag-products-that-meet-a-sales-threshold)
+* [Auto-tag products when another tag is added](./auto-tag-products-when-another-tag-is-added)
+* [Auto-tag products when their variants change](./auto-tag-products-when-their-skus-change)
+* [Auto-tag products with incoming inventory](./auto-tag-products-with-incoming-inventory)
+* [Auto-tag products with their vendors](./auto-tag-products-with-their-vendors)
+* [Auto-tag products without descriptions](./auto-tag-products-without-descriptions)
+* [Auto-update inventory policy based on a "preorder" tag](./auto-update-inventory-policy-based-on-a-preorder-tag)
+* [Automatically publish and unpublish on a monthly cycle](./automatically-publish-and-unpublish-on-a-monthly-cycle)
+* [Calculate total quantities purchased by SKU](./calculate-total-quantities-purchased-by-sku)
+* [Catalog update email](./catalog-update-email)
+* [Copy prefixed tags to metafields](./copy-prefixed-tags-to-metafields)
+* [Copy product metafields to each product's tags](./copy-product-metafields-to-each-products-tags)
+* [Create a product inventory CSV feed](./create-a-product-inventory-feed)
+* [Delete all products](./delete-all-products)
+* [Delete product or product variant metafields in bulk](./delete-product-or-product-variant-metafields-in-bulk)
+* [Delete the oldest x products from a specific collection](./delete-the-oldest-x-products-from-a-specific-collection)
+* [Email a CSV export of products](./email-a-csv-export-of-products)
+* [Email a summary of all products and quantities ordered](./email-a-summary-of-all-products-and-quantities-ordered)
+* [Email customers after purchasing a certain product](./product-order-email)
+* [Email someone when a certain product is purchased](./email-someone-when-certain-product-purchased)
+* [Email someone when a certain variant is purchased](./email-when-variant-purchased)
+* [Email vendors when their products are ordered](./email-vendors-when-their-products-are-ordered)
+* [Find duplicate SKUs](./find-duplicate-skus)
+* [Generate a discount code when a certain product is purchased](./generate-a-discount-code-when-a-certain-product-is-purchased)
+* [Generate a product discount when a voucher product is purchased](./generate-a-product-discount-when-a-voucher-product-is-purchased)
+* [Hide out-of-stock products](./hide-out-of-stock-products)
+* [Keep inventory levels in sync within products](./keep-inventory-levels-in-sync-within-products)
+* [Maintain a collection of new products](./maintain-a-collection-of-new-products)
+* [Maintain a collection of recently purchased products](./maintain-a-collection-of-recently-purchased-products)
+* [Maintain collections by product metafield values](./maintain-collections-by-product-metafield-values)
+* [Maintain inventory for a product bundle](./maintain-inventory-for-a-product-bundle)
+* [Make products unavailable, after the date/time stored in product metafields](./make-products-unavailable-after-the-date-time-stored-in-product-metafields)
+* [Manage tagging for a time-limited membership product](./manage-tagging-for-a-time-limited-membership-product)
+* [Notify a team when a tagged product is ordered](./notify-a-team-when-a-tagged-product-is-ordered)
+* [Publish back-in-stock products](./publish-back-in-stock-products)
+* [Raise the price of a product after every sale](./raise-the-price-of-a-product-after-every-sale)
+* [Remove tag from all products](./remove-specified-tags-from-all-products)
+* [Rotate products through a featured collection](./rotate-products-through-a-featured-collection)
+* [Schedule product status to active](./schedule-product-status-to-active)
+* [Schedule product tags by date](./schedule-product-tags-by-date)
+* [Send an SMS via Nexmo when a product is created](./send-an-sms-via-nexmo-when-a-product-is-created)
+* [Send an email alert if a new collection has no orders after x days](./send-an-email-alert-if-a-new-collection-has-no-orders-after-x-days)
+* [Send an email alert when a variant hits 0 total inventory](./send-an-email-alert-when-a-variant-hits-0-total-inventory)
+* [Send an email when a product's price goes below its cost](./send-an-email-when-a-products-price-goes-below-its-cost)
+* [Send an email when a specific product is shipped](./send-an-email-when-a-specific-product-is-shipped)
+* [Set product or variant metafields values in bulk](./set-product-or-variant-metafields-in-bulk)
+* [Set product templates based on product tags](./set-product-templates-based-on-product-tags)
+* [Sync inventory across a product type](./sync-inventory-across-a-product-type)
+* [Sync inventory across product variants](./sync-inventory-across-product-variants)
+* [Sync inventory levels to variant metafields](./sync-inventory-levels-to-variant-metafields)
+* [Sync variant inventory within a product by pack size](./sync-variant-inventory-within-a-product-by-pack-size)
+* [Tag products as in- or out-of-stock](./tag-products-as-in-or-out-of-stock)
+* [Tag products by their price ranges](./tag-products-by-their-price-ranges)
+* [Tag products with no images](./tag-products-with-no-images)
+* [Track incoming donations in a store metafield](./track-incoming-donations-in-a-store-metafield)
+* [Unpublish products from markets when locations are out of stock](./unpublish-products-from-markets-when-locations-are-out-of-stock)
+* [Unpublish products that fall below a rolling sales threshold](./unpublish-products-that-fall-below-a-rolling-sales-threshold)
+* [Unpublish products that have been out of stock for x days](./unpublish-products-that-have-been-out-of-stock-for-x-days)
+* [Unpublish products when tagged](./unpublish-products-when-tagged)
+
+### Publish
+
+* [Advanced: Scheduled section publishing](./advanced-scheduled-section-publishing)
+* [Auto publish products by tag](./auto-publish-products-by-tag)
+* [Auto-create collections by product type or vendor](./auto-create-collections-by-product-type-or-vendor)
+* [Auto-publish new products](./auto-publish-new-products)
+* [Auto-publish products tagged with the current day](./auto-publish-products-tagged-with-the-current-day)
+* [Auto-tag products based on their publishing status](./auto-tag-products-based-on-their-publishing-status)
+* [Auto-tag products by their publish date](./auto-tag-products-by-their-publish-date)
+* [Automatically publish and unpublish on a monthly cycle](./automatically-publish-and-unpublish-on-a-monthly-cycle)
+* [Publish a certain collection, daily](./publish-a-certain-collection-daily)
+* [Publish back-in-stock products](./publish-back-in-stock-products)
+* [Scheduled theme publishing](./scheduled-theme-publishing)
+
+### Recurring
+
+* [Auto-recurring draft orders](./auto-recurring-draft-orders)
+
+### Redirects
+
+* [Redirect users based on input codes](./redirect-users-based-on-input-codes)
+
+### Referral
+
+* [Tag online orders by their ?ref= referral codes](./tag-orders-by-url-referrer)
+
+### Refunds
+
+* [Auto-untag customers when a certain product is refunded](./auto-untag-customers-when-a-certain-product-is-refunded)
+* [Cancel fulfillments when an order is fully refunded](./cancel-fulfillments-when-an-order-is-fully-refunded)
+
+### Reminder
+
+* [Remind customers after x days about unpaid orders](./remind-customers-after-x-days-about-unpaid-orders)
+* [Remind customers that their order is on the way](./remind-customers-that-their-order-is-on-the-way)
+* [Send your customers reorder reminders](./send-your-customers-reorder-reminders)
+
+### Report
+
+* [Demonstration: Generate product sales report PDF with pie chart](./demonstration-generate-product-sales-report-pdf-with-pie-chart)
+* [Email a report of customers who haven't ordered in X days](./email-a-report-of-customers-who-havent-ordered-in-x-days)
+* [Generate a report of orders that still require payment](./generate-a-report-of-orders-that-still-require-payment)
+* [Receive a nightly out-of-stock report](./receive-a-nightly-out-of-stock-report)
+* [Report Toaster: Deliver report PDF via email or Slack](./report-toaster-deliver-report-pdf-via-email-or-slack)
+
+### Report Toaster
+
+* [Report Toaster: Deliver report PDF via email or Slack](./report-toaster-deliver-report-pdf-via-email-or-slack)
+* [Report Toaster: Pirate Ship Integration](./report-toaster-pirateship-integration)
+* [Report Toaster: ShipStation Integration](./report-toaster-shipstation-integration)
+
+### Retention
+
+* [Abandoned checkout emails](./abandoned-checkout-emails)
+* [Auto-invite customers after an order](./auto-invite-customers-after-an-order)
+* [Email a report of customers who haven't ordered in X days](./email-a-report-of-customers-who-havent-ordered-in-x-days)
+* [Email your customers after a quiet period of no orders](./email-your-customers-after-a-quiet-period-of-no-orders)
+* [Generate a discount code when a certain product is purchased](./generate-a-discount-code-when-a-certain-product-is-purchased)
+* [Send a welcome email to new customers, in their language](./send-a-welcome-email-to-new-customers-in-their-language)
+* [Send customers a reorder link X days after ordering](./send-customers-a-reorder-link-x-days-after-ordering)
+* [Tag customers by order tier](./tag-customers-by-order-tier)
+
+### Reviews
+
+* [Ask for reviews a week after order fulfillment](./ask-for-reviews-a-week-after-order-fulfillment)
+* [Record Judge.me customer review counts](./record-judge-me-customer-review-counts)
+* [Send a follow-up email to customers after purchasing from a certain vendor](./send-a-follow-up-email-to-customers-after-purchasing-from-a-certain-vendor)
+
+### Risk
+
+* [Auto-capture order payments based on Kount risk assessments](./auto-capture-order-payments-based-on-kount-risk-assessments)
+* [Auto-capture payments when an order is created](./auto-capture-payments-when-an-order-is-created)
+* [Auto-tag orders by their risk level](./auto-tag-orders-by-their-risk-level)
+* [Auto-tag orders from recurring client IP addresses](./auto-tag-orders-from-recurring-client-ip-addresses)
+* [Auto-tag orders with chargeback or inquiry activity](./auto-tag-orders-with-chargeback-or-inquiry-activity)
+* [Auto-tag orders with mismatching billing and shipping addresses](./auto-tag-orders-with-mismatching-billing-and-shipping-addresses)
+* [Automatically cancel high-risk orders](./automatically-cancel-high-risk-orders)
+* [Automatically cancel orders with certain risk indicators](./automatically-cancel-orders-with-certain-risk-indicators)
+* [Send an email alert when a customer places more than 2 orders in 24 hours](./send-an-email-alert-when-a-customer-places-more-than-2-orders-in-24-hours)
+
+### SKU
+
+* [Auto-add bundle components to orders, post-purchase](./auto-add-bundle-components-to-orders-post-purchase)
+* [Auto-cancel orders with too many of a certain SKU](./auto-cancel-orders-with-too-many-of-a-certain-sku)
+* [Auto-generate SKUs](./auto-generate-skus)
+* [Auto-tag customers by purchased SKUs](./auto-tag-customers-by-purchased-skus)
+* [Calculate total quantities purchased by SKU](./calculate-total-quantities-purchased-by-sku)
+* [Find duplicate SKUs](./find-duplicate-skus)
+* [Keep SKUs up to date with barcodes](./keep-skus-up-to-date-with-barcodes)
+* [Maintain inventory for a product bundle](./maintain-inventory-for-a-product-bundle)
+* [Sync inventory for shared SKUs](./sync-inventory-for-shared-skus)
+
+### SMS
+
+* [Send an SMS via Nexmo when a product is created](./send-an-sms-via-nexmo-when-a-product-is-created)
+
+### Sale
+
+* [Advanced: Scheduled Price Changes](./advanced-scheduled-price-changes)
+
+### Sales Channel
+
+* [Add all products to a certain sales channel](./add-all-products-to-a-certain-sales-channel)
+* [Auto publish products by tag](./auto-publish-products-by-tag)
+* [Auto-tag customers by sales channel](./auto-tag-customers-by-sales-channel)
+* [Auto-tag orders by sales channel](./auto-tag-orders-by-sales-channel)
+
+### Schedule
+
+* [Activate a discount when ISS passes overhead](./activate-a-discount-when-iss-passes-overhead)
+* [Advanced: Scheduled Price Changes](./advanced-scheduled-price-changes)
+* [Advanced: Scheduled section publishing](./advanced-scheduled-section-publishing)
+* [Auto-capture order payment after x days](./auto-capture-order-payment-after-x-days)
+* [Auto-remove a customer tag x days after it's added](./auto-remove-a-customer-tag-x-days-after-its-added)
+* [Auto-remove a product tag x days after it's added](./auto-remove-a-product-tag-x-days-after-its-added)
+* [Delete draft orders older than 30 days](./delete-draft-orders-older-than-30-days)
+* [Delete variants having a metafield date that has passed](./delete-variants-having-a-metafield-date-that-has-passed)
+* [Email customers a unique discount code, two weeks after order fulfillment](./email-customers-a-unique-discount-code-two-weeks-after-order-fulfillment)
+* [Publish a certain collection, daily](./publish-a-certain-collection-daily)
+* [Receive a nightly out-of-stock report](./receive-a-nightly-out-of-stock-report)
+* [Remind customers after x days about unpaid orders](./remind-customers-after-x-days-about-unpaid-orders)
+* [Reset inventory levels daily](./reset-inventory-levels-daily)
+* [Schedule a storefront banner](./schedule-a-storefront-banner)
+* [Schedule customer auto-tagging after a purchase](./schedule-customer-auto-tagging-after-a-purchase)
+* [Schedule product status to active](./schedule-product-status-to-active)
+* [Schedule product tags by date](./schedule-product-tags-by-date)
+* [Scheduled theme publishing](./scheduled-theme-publishing)
+* [Unpublish a certain collection, daily](./unpublish-a-certain-collection-daily)
+
+### Sections
+
+* [Advanced: Scheduled section publishing](./advanced-scheduled-section-publishing)
+
+### Segment
+
+* [Tag and segment customers by days since last order](./tag-and-segment-customers-by-days-since-last-order)
+
+### Shipping
+
+* [Auto-capture order payment based on shipping method](./auto-capture-order-payment-based-on-shipping-method)
+* [Auto-prefix tracking numbers for each new fulfillment](./auto-prefix-tracking-numbers-for-each-new-fulfillment)
+* [Auto-tag fulfilled orders by carrier](./auto-tag-fulfilled-orders-by-carrier)
+* [Auto-tag fulfilled orders with their carriers](./auto-tag-fulfilled-orders-with-their-carriers)
+* [Auto-tag open orders from the same customer with the same shipping address](./auto-tag-open-orders-from-same-customer-and-shipping-address)
+* [Auto-tag orders based on shipping method](./auto-tag-orders-based-on-shipping-method)
+* [Auto-tag orders by shipment status](./auto-tag-orders-by-shipment-status)
+* [Auto-tag orders by shipping address city](./auto-tag-orders-by-shipping-address-city)
+* [Auto-tag orders by shipping address country](./auto-tag-orders-by-shipping-address-country)
+* [Auto-tag orders that are ready to ship](./auto-tag-orders-that-are-ready-to-ship)
+* [Auto-tag orders with mismatching billing and shipping addresses](./auto-tag-orders-with-mismatching-billing-and-shipping-addresses)
+* [Auto-tag orders with their tracking numbers](./auto-tag-orders-with-their-tracking-numbers)
+* [Email the customer when tracking numbers are added to their order](./email-the-customer-when-tracking-numbers-are-added-to-their-order)
+* [Email vendors when an order shipping address changes](./email-vendors-when-an-order-shipping-address-changes)
+* [Export a CSV of order shipping addresses](./export-a-csv-of-order-shipping-addresses)
+* [Manage fulfillment shipment status using order tags](./manage-fulfillment-status-using-order-tags)
+* [Remind customers that their order is on the way](./remind-customers-that-their-order-is-on-the-way)
+* [Report Toaster: Pirate Ship Integration](./report-toaster-pirateship-integration)
+* [Report Toaster: ShipStation Integration](./report-toaster-shipstation-integration)
+* [Send a staff notification email for each delivery](./send-a-staff-notification-email-for-each-delivery)
+* [Send an email alert when an incoming Canadian order has an unsupported FSA](./send-an-email-alert-when-an-incoming-canadian-order-has-an-unsupported-fsa)
+* [Send an email when a specific product is shipped](./send-an-email-when-a-specific-product-is-shipped)
+* [Set a default tracking number for new fulfillments](./set-a-default-tracking-number-for-new-fulfillments)
+* [Standardize UK postcodes](./standardize-uk-shipping-postcodes)
+
+### Shopify Flow
+
+* [Bulk trigger Shopify Flow with historical data](./bulk-trigger-shopify-flow-with-historical-data)
+* [Demonstration: Shopify Flow integration](./demonstration-shopify-flow-integration)
+* [Trigger Shopify Flow with a time delay](./trigger-shopify-flow-with-a-time-delay)
+
+### Signup
+
+* [Send a customer signup email](./customer-signup-email)
+
+### Slack
+
+* [Report Toaster: Deliver report PDF via email or Slack](./report-toaster-deliver-report-pdf-via-email-or-slack)
+* [Send a message to Slack](./send-a-message-to-slack)
+
+### Sort
+
+* [Auto-sort collections by inventory levels](./auto-sort-collections-by-inventory-levels)
+* [Auto-sort collections by product properties](./auto-sort-collections-by-product-properties)
+* [Move out-of-stock products to the end of a collection](./move-out-of-stock-products-to-the-end-of-a-collection)
+
+### Spend
+
+* [Auto-tag customers having a rolling minimum total spend](./auto-tag-customers-having-a-rolling-minimum-total-spend)
+
+### Staff
+
+* [Auto-tag draft orders by originating staff member](./auto-tag-draft-orders-by-originating-staff-member)
+* [Auto-tag new orders by staff member](./auto-tag-new-orders-by-staff-member)
+* [Auto-tag orders by originating staff member](./auto-tag-orders-by-originating-staff-member)
+
+### Status
+
+* [Schedule product status to active](./schedule-product-status-to-active)
+
+### Storefront
+
+* [Schedule a storefront banner](./schedule-a-storefront-banner)
+
+### Subscriptions
+
+* [Auto-tag orders that contain subscription products](./auto-tag-orders-that-contain-subscription-products)
+
+### Sync
+
+* [Auto-copy order notes to the customer's note](./auto-copy-order-notes-to-the-customers-note)
+* [Keep inventory levels in sync within products](./keep-inventory-levels-in-sync-within-products)
+* [Maintain inventory for a product bundle](./maintain-inventory-for-a-product-bundle)
+* [Sync an inverse customer tag](./sync-an-inverse-customer-tag)
+* [Sync an inverse order tag](./sync-an-inverse-order-tag)
+* [Sync inventory across a product type](./sync-inventory-across-a-product-type)
+* [Sync inventory across product variants](./sync-inventory-across-product-variants)
+* [Sync inventory for shared SKUs](./sync-inventory-for-shared-skus)
+* [Sync inventory levels to variant metafields](./sync-inventory-levels-to-variant-metafields)
+* [Sync order timeline comments to the customer note](./sync-order-timeline-comments-to-the-customer-note)
+* [Sync variant inventory within a product by pack size](./sync-variant-inventory-within-a-product-by-pack-size)
+
+### Tag
+
+* [Add fulfillment tracking when an order is tagged](./add-fulfillment-tracking-when-an-order-is-tagged)
+* [Archive orders when tagged](./archive-orders-when-tagged)
+* [Auto-associate products with a delivery profile, by product tag](./auto-associate-products-with-a-delivery-profile-by-product-tag)
+* [Auto-cancel fulfillments when an order is tagged](./auto-cancel-fulfillments-when-an-order-is-tagged)
+* [Auto-fulfill orders when tagged](./auto-fulfill-orders-when-tagged)
+* [Auto-invite customers when tagged](./auto-invite-customers-when-tagged)
+* [Auto-pay orders from customers with a certain tag](./auto-pay-orders-from-customers-with-a-certain-tag)
+* [Auto-pay orders having a certain tag](./auto-pay-orders-having-a-certain-tag)
+* [Auto-publish products tagged with the current day](./auto-publish-products-tagged-with-the-current-day)
+* [Auto-tag a customer's first order](./auto-tag-a-customers-first-order)
+* [Auto-tag customers when another tag is added](./auto-tag-customers-when-another-tag-is-added)
+* [Auto-tag customers when their order is tagged](./auto-tag-customers-when-their-order-is-tagged)
+* [Auto-tag orders that do not have a certain tag](./auto-tag-orders-that-do-not-have-a-certain-tag)
+* [Auto-tag orders when another tag is added](./auto-tag-orders-when-another-tag-is-added)
+* [Auto-tag products when another tag is added](./auto-tag-products-when-another-tag-is-added)
+* [Auto-update inventory policy based on a "preorder" tag](./auto-update-inventory-policy-based-on-a-preorder-tag)
+* [Copy prefixed tags to metafields](./copy-prefixed-tags-to-metafields)
+* [Copy product metafields to each product's tags](./copy-product-metafields-to-each-products-tags)
+* [Demonstration: Auto-tag new orders, with scheduled reconciliation](./demonstration-auto-tag-new-orders-with-reconciliation)
+* [Email customers when tagged](./email-customers-when-tagged)
+* [Email customers when their order is tagged](./email-customer-when-order-tagged)
+* [Email vendors when an order is tagged](./email-vendors-when-an-order-is-tagged)
+* [Manage fulfillment shipment status using order tags](./manage-fulfillment-status-using-order-tags)
+* [Manage tagging for a time-limited membership product](./manage-tagging-for-a-time-limited-membership-product)
+* [Remove tag from all products](./remove-specified-tags-from-all-products)
+* [Send email when an order is tagged](./send-email-when-an-order-is-tagged)
+* [Set product templates based on product tags](./set-product-templates-based-on-product-tags)
+* [Tag and segment customers by days since last order](./tag-and-segment-customers-by-days-since-last-order)
+* [Tag customers by order tier](./tag-customers-by-order-tier)
+* [Tag customers in bulk by email address](./tag-customers-in-bulk-by-email-address)
+* [Tag customers on the anniversary of their first order](./tag-customers-on-the-anniversary-of-their-first-order)
+* [Tag products with no images](./tag-products-with-no-images)
+* [Temporarily enable tax-exempt status when a customer is tagged](./temporarily-enable-tax-exempt-status-when-a-customer-is-tagged)
+* [Trigger order emails with a tag](./trigger-order-emails-with-a-tag)
+* [Unpublish products when tagged](./unpublish-products-when-tagged)
+
+### Tax
+
+* [Temporarily enable tax-exempt status when a customer is tagged](./temporarily-enable-tax-exempt-status-when-a-customer-is-tagged)
+
+### Template
+
+* [Set product templates based on product tags](./set-product-templates-based-on-product-tags)
+
+### Time-Limited
+
+* [Manage tagging for a time-limited membership product](./manage-tagging-for-a-time-limited-membership-product)
+
+### Timeline
+
+* [Sync order timeline comments to the customer note](./sync-order-timeline-comments-to-the-customer-note)
+
+### Tracking
+
+* [Add fulfillment tracking when an order is tagged](./add-fulfillment-tracking-when-an-order-is-tagged)
+* [Auto-prefix tracking numbers for each new fulfillment](./auto-prefix-tracking-numbers-for-each-new-fulfillment)
+* [Auto-tag orders with their tracking numbers](./auto-tag-orders-with-their-tracking-numbers)
+* [Email the customer when tracking numbers are added to their order](./email-the-customer-when-tracking-numbers-are-added-to-their-order)
+* [Set a default tracking number for new fulfillments](./set-a-default-tracking-number-for-new-fulfillments)
+
+### Transfer
+
+* [Auto-tag products with incoming inventory](./auto-tag-products-with-incoming-inventory)
+
+### Tutorial
+
+* [Tutorial: Trigger a task from a contact form, using webhooks](./tutorial-trigger-a-task-from-a-contact-form-using-webhooks)
+
+### UK
+
+* [Standardize UK postcodes](./standardize-uk-shipping-postcodes)
+
+### Uncategorized
+
+* [Mechanic tour task](./mechanic-tour-task)
+
+### Unpaid
+
+* [Cancel and close unpaid orders after x hours/days](./cancel-and-close-unpaid-orders-after-two-days)
+* [Generate a report of orders that still require payment](./generate-a-report-of-orders-that-still-require-payment)
+* [Remind customers after x days about unpaid orders](./remind-customers-after-x-days-about-unpaid-orders)
+* [Send recurring reminders about unpaid orders](./unpaid-order-reminders)
+
+### Unpublish
+
+* [Advanced: Scheduled section publishing](./advanced-scheduled-section-publishing)
+* [Auto publish products by tag](./auto-publish-products-by-tag)
+* [Automatically publish and unpublish on a monthly cycle](./automatically-publish-and-unpublish-on-a-monthly-cycle)
+* [Hide out-of-stock products](./hide-out-of-stock-products)
+* [Make products unavailable, after the date/time stored in product metafields](./make-products-unavailable-after-the-date-time-stored-in-product-metafields)
+* [Unpublish a certain collection, daily](./unpublish-a-certain-collection-daily)
+* [Unpublish products from markets when locations are out of stock](./unpublish-products-from-markets-when-locations-are-out-of-stock)
+* [Unpublish products that fall below a rolling sales threshold](./unpublish-products-that-fall-below-a-rolling-sales-threshold)
+* [Unpublish products that have been out of stock for x days](./unpublish-products-that-have-been-out-of-stock-for-x-days)
+* [Unpublish products when tagged](./unpublish-products-when-tagged)
+
+### Untag
+
+* [Auto-remove a customer tag x days after it's added](./auto-remove-a-customer-tag-x-days-after-its-added)
+* [Auto-remove a product tag x days after it's added](./auto-remove-a-product-tag-x-days-after-its-added)
+* [Auto-untag customers when a certain product is refunded](./auto-untag-customers-when-a-certain-product-is-refunded)
+* [Remove a customer tag when another tag is added](./remove-a-customer-tag-when-another-tag-is-added)
+* [Remove an order tag when another tag is added](./remove-a-order-tag-when-another-tag-is-added)
+* [Untag orders when paid](./untag-orders-when-paid)
+
+### Variants
+
+* [Add Option Name as a Variant Metafield for In Stock Variants](./add-option-names-as-variant-metafields-for-in-stock-variants)
+* [Auto-associate variants with a delivery profile, by metafield value](./auto-associate-variants-with-a-delivery-profile-by-metafield-value)
+* [Auto-tag products by largest available size](./auto-tag-products-by-largest-available-size)
+* [Maintain discount percentage filters in variant metafields](./maintain-discount-percentage-filters-in-variant-metafields)
+* [Send an email when a product's price goes below its cost](./send-an-email-when-a-products-price-goes-below-its-cost)
+* [Set product or variant metafields values in bulk](./set-product-or-variant-metafields-in-bulk)
+* [Sync inventory across product variants](./sync-inventory-across-product-variants)
+* [Sync inventory levels to variant metafields](./sync-inventory-levels-to-variant-metafields)
+
+### Vendor
+
+* [Auto-create collections by product type or vendor](./auto-create-collections-by-product-type-or-vendor)
+* [Auto-tag customers with vendors after ordering](./auto-tag-customers-with-vendors-after-ordering)
+* [Auto-tag orders with product vendors](./auto-tag-orders-with-product-vendors)
+* [Auto-tag products with their vendors](./auto-tag-products-with-their-vendors)
+* [Email vendors when an order is tagged](./email-vendors-when-an-order-is-tagged)
+* [Email vendors when an order shipping address changes](./email-vendors-when-an-order-shipping-address-changes)
+* [Email vendors when their products are ordered](./email-vendors-when-their-products-are-ordered)
+* [Send a follow-up email to customers after purchasing from a certain vendor](./send-a-follow-up-email-to-customers-after-purchasing-from-a-certain-vendor)
+
+### Watch
+
+* [Add fulfillment tracking when an order is tagged](./add-fulfillment-tracking-when-an-order-is-tagged)
+* [Auto-add products to a custom collection when tagged](./auto-add-products-to-a-custom-collection-when-tagged)
+* [Auto-cancel fulfillments when an order is tagged](./auto-cancel-fulfillments-when-an-order-is-tagged)
+* [Auto-invite customers when tagged](./auto-invite-customers-when-tagged)
+* [Auto-pay orders from customers with a certain tag](./auto-pay-orders-from-customers-with-a-certain-tag)
+* [Auto-pay orders having a certain tag](./auto-pay-orders-having-a-certain-tag)
+* [Auto-publish products tagged with the current day](./auto-publish-products-tagged-with-the-current-day)
+* [Auto-tag customers when their order is tagged](./auto-tag-customers-when-their-order-is-tagged)
+* [Auto-tag new products by "back in stock" age](./auto-tag-new-products-by-back-in-stock-age)
+* [Auto-tag orders when another tag is added](./auto-tag-orders-when-another-tag-is-added)
+* [Auto-tag products when another tag is added](./auto-tag-products-when-another-tag-is-added)
+* [Auto-update inventory policy based on a "preorder" tag](./auto-update-inventory-policy-based-on-a-preorder-tag)
+* [Email customers when tagged](./email-customers-when-tagged)
+* [Email customers when their order is tagged](./email-customer-when-order-tagged)
+* [Email vendors when an order is tagged](./email-vendors-when-an-order-is-tagged)
+* [Generate a product discount when a voucher product is purchased](./generate-a-product-discount-when-a-voucher-product-is-purchased)
+* [Maintain a collection of new products](./maintain-a-collection-of-new-products)
+* [Monitor customer note for certain information](./monitor-customer-note-for-certain-information)
+* [Notify a team when a tagged product is ordered](./notify-a-team-when-a-tagged-product-is-ordered)
+* [Remove a customer tag when another tag is added](./remove-a-customer-tag-when-another-tag-is-added)
+* [Remove an order tag when another tag is added](./remove-a-order-tag-when-another-tag-is-added)
+* [Send email when an order is tagged](./send-email-when-an-order-is-tagged)
+* [Trigger order emails with a tag](./trigger-order-emails-with-a-tag)
+
+### Web Browser
+
+* [Auto-tag new online orders by web browser](./auto-tag-new-online-orders-by-web-browser)

--- a/lib/util.js
+++ b/lib/util.js
@@ -95,6 +95,7 @@ module.exports.buildDocs = (docsDir = 'docs', options = {}) => {
 
   const tasks = glob.sync('tasks/*.json')
   const taskIndexMdLines = []
+  const tagHash = {}
 
   if (fs.existsSync(docsDir)) {
     fs.rmSync(docsDir, {recursive: true})
@@ -113,7 +114,14 @@ module.exports.buildDocs = (docsDir = 'docs', options = {}) => {
 
       const description = `${task.docs}`.split(/(\r?\n){2,}/)[0];
 
-      taskIndexMdLines.push(`* [${task.name}](./${taskHandle})`)
+      const markdownLinkToTask = `* [${task.name}](./${taskHandle})`
+      taskIndexMdLines.push(markdownLinkToTask)
+
+      const addToTagHash = tag => {
+        if (!tagHash[tag]) tagHash[tag] = []
+        tagHash[tag].push(markdownLinkToTask)
+      }
+      task.tags ? task.tags.forEach(addToTagHash) : addToTagHash('Uncategorized')
 
       // write script.liquid
       fs.writeFileSync(`${taskDocsDir}/script.liquid`, task.script)
@@ -210,6 +218,14 @@ module.exports.buildDocs = (docsDir = 'docs', options = {}) => {
   let taskIndexMd = `# Task documentation index`
   taskIndexMd += `\n\nThis directory is built automatically. Each task's documentation is generated from the corresponding task export file in [../tasks](../tasks/). To contribute, see [../CONTRIBUTING.md](../CONTRIBUTING.md).`
   taskIndexMd += `\n\n${taskIndexMdLines.join("\n")}\n`
+
+  taskIndexMd += `\n\n## Tasks grouped by tags\n`
+  const allTagsSorted = Object.keys(tagHash).sort()
+  allTagsSorted.forEach(tag => {
+    tagHash[tag].sort()
+    taskIndexMd += `\n### ${tag}\n`
+    taskIndexMd += `\n${tagHash[tag].join('\n')}\n`
+  })
 
   fs.writeFileSync(`${docsDir}/README.md`, taskIndexMd)
 


### PR DESCRIPTION
I came to `docs/README.md` and was overwhelmed and lost in the huuuuuge task list.
I figured there's already this whole powerful and well-organized system for grouping tasks by tags, so why not use it in the docs index?
I put tasks grouped by tags below the gigantic alphabetical list of tasks. Perhaps we should move it above instead?

Thanks!

You can preview the new `docs/README.md` here: https://github.com/vfonic/mechanic-tasks/blob/docs/group-tasks-by-tags/docs/README.md