### PR TITLE
new task: send email notification when items are returned

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -294,6 +294,7 @@ This directory is built automatically. Each task's documentation is generated fr
 * [Send an event to Klaviyo when a fulfillment is delayed](./send-an-event-to-klaviyo-when-a-fulfillment-is-delayed)
 * [Send customers a reorder link X days after ordering](./send-customers-a-reorder-link-x-days-after-ordering)
 * [Send email alerts by event topic](./send-email-alerts-by-event-topic)
+* [Send email notification when items are returned](./send-email-notification-when-items-are-returned)
 * [Send email when an order comes in](./send-email-when-an-order-comes-in)
 * [Send email when an order is tagged](./send-email-when-an-order-is-tagged)
 * [Send follow-up emails after sending a draft order invoice](./send-follow-up-emails-after-sending-a-draft-order-invoice)
@@ -398,6 +399,7 @@ This directory is built automatically. Each task's documentation is generated fr
 * [Send an email alert when a fulfillment is cancelled](./send-an-email-alert-when-a-fulfillment-is-cancelled)
 * [Send an email alert when a variant hits 0 total inventory](./send-an-email-alert-when-a-variant-hits-0-total-inventory)
 * [Send an email alert when an incoming Canadian order has an unsupported FSA](./send-an-email-alert-when-an-incoming-canadian-order-has-an-unsupported-fsa)
+* [Send email notification when items are returned](./send-email-notification-when-items-are-returned)
 * [Send email when an order comes in](./send-email-when-an-order-comes-in)
 
 ### Archive
@@ -828,6 +830,7 @@ This directory is built automatically. Each task's documentation is generated fr
 * [Send an email when a purchase is made from a certain collection](./send-an-email-when-a-purchase-is-made-from-a-certain-collection)
 * [Send an email when a specific product is shipped](./send-an-email-when-a-specific-product-is-shipped)
 * [Send customers a reorder link X days after ordering](./send-customers-a-reorder-link-x-days-after-ordering)
+* [Send email notification when items are returned](./send-email-notification-when-items-are-returned)
 * [Send email when an order comes in](./send-email-when-an-order-comes-in)
 * [Send email when an order is tagged](./send-email-when-an-order-is-tagged)
 * [Send follow-up emails after sending a draft order invoice](./send-follow-up-emails-after-sending-a-draft-order-invoice)
@@ -1422,6 +1425,10 @@ This directory is built automatically. Each task's documentation is generated fr
 * [Send a welcome email to new customers, in their language](./send-a-welcome-email-to-new-customers-in-their-language)
 * [Send customers a reorder link X days after ordering](./send-customers-a-reorder-link-x-days-after-ordering)
 * [Tag customers by order tier](./tag-customers-by-order-tier)
+
+### Returns
+
+* [Send email notification when items are returned](./send-email-notification-when-items-are-returned)
 
 ### Reviews
 

--- a/docs/send-email-notification-when-items-are-returned/README.md
+++ b/docs/send-email-notification-when-items-are-returned/README.md
@@ -1,0 +1,45 @@
+# Send email notification when items are returned
+
+Tags: Alert, Email, Returns
+
+Use this task to get an email alert with a list of the returned items whenever a return is marked as closed.
+
+* View in the task library: [tasks.mechanic.dev/send-email-notification-when-items-are-returned](https://tasks.mechanic.dev/send-email-notification-when-items-are-returned)
+* Task JSON, for direct import: [task.json](../../tasks/send-email-notification-when-items-are-returned.json)
+* Preview task code: [script.liquid](./script.liquid)
+
+## Default options
+
+```json
+{
+  "email_recipients__array_required": null
+}
+```
+
+[Learn about task options in Mechanic](https://learn.mechanic.dev/core/tasks/options)
+
+## Subscriptions
+
+```liquid
+shopify/returns/close
+```
+
+[Learn about event subscriptions in Mechanic](https://learn.mechanic.dev/core/tasks/subscriptions)
+
+## Documentation
+
+Use this task to get an email alert with a list of the returned items whenever a return is marked as closed.
+
+Note: this event will not occur when returns or exchanges are made via a POS terminal.
+
+## Installing this task
+
+Find this task [in the library at tasks.mechanic.dev](https://tasks.mechanic.dev/send-email-notification-when-items-are-returned), and use the "Try this task" button. Or, import [this task's JSON export](../../tasks/send-email-notification-when-items-are-returned.json) – see [Importing and exporting tasks](https://learn.mechanic.dev/core/tasks/import-and-export) to learn how imports work.
+
+## Contributions
+
+Found a bug? Got an improvement to add? Start here: [../../CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Task requests
+
+Submit your [task requests](https://mechanic.canny.io/task-requests) for consideration by the Mechanic community, and they may be chosen for development and inclusion in the [task library](https://tasks.mechanic.dev/)!

--- a/docs/send-email-notification-when-items-are-returned/script.liquid
+++ b/docs/send-email-notification-when-items-are-returned/script.liquid
@@ -1,0 +1,76 @@
+{% assign email_recipients = options.email_recipients__array_required %}
+
+{% if event.topic == "shopify/returns/close" %}
+  {% capture query %}
+    query {
+      return(id: {{ return.admin_graphql_api_id | json }}) {
+        name
+        returnLineItems(first: 100) {
+          nodes {
+            quantity
+            returnReason
+            fulfillmentLineItem {
+              lineItem {
+                name
+                sku
+              }
+            }
+          }
+        }
+      }
+    }  
+  {% endcapture %}
+  
+  {% assign result = query | shopify %}
+  
+  {% if event.preview %}
+    {% capture result_json %}
+      {
+        "data": {
+          "return": {
+            "name": "#PREVIEW-R1",
+            "returnLineItems": {
+              "nodes": [
+                {
+                  "quantity": 1,
+                  "returnReason": "STYLE",
+                  "fulfillmentLineItem": {
+                    "lineItem": {
+                      "name": "Widget - Chartreuse",
+                      "sku": "WDGT-CHRTRS"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    {% endcapture %}
+  
+    {% assign result = result_json | parse_json %}
+  {% endif %}
+  
+  {% capture email_subject %}ALERT: New return {{ result.data.return.name }}{% endcapture %}
+
+  {% capture email_body -%}
+    Returned items
+    ==============
+    {% for return_line_item in result.data.return.returnLineItems.nodes %}
+      Title: <strong>{{ return_line_item.fulfillmentLineItem.lineItem.name }}</strong>
+      SKU: <strong>{{ return_line_item.fulfillmentLineItem.lineItem.sku }}</strong>
+      Quantity: <strong>{{ return_line_item.quantity }}</strong>
+      Reason: <strong>{{ return_line_item.returnReason }}</strong>
+    {% endfor %}
+  {% endcapture %}
+
+  {% action "email" %}
+    {
+      "to": {{ email_recipients | json }},
+      "subject": {{ email_subject | json }},
+      "body": {{ email_body | newline_to_br | json }},
+      "reply_to": {{ shop.customer_email | json }},
+      "from_display_name": {{ shop.name | json }}
+    }
+  {% endaction %}
+{% endif %}

--- a/lib/task_schema.json
+++ b/lib/task_schema.json
@@ -96,6 +96,7 @@
           "Report",
           "Report Toaster",
           "Retention",
+          "Returns",
           "Reviews",
           "Risk",
           "Sections",

--- a/tasks/send-email-notification-when-items-are-returned.json
+++ b/tasks/send-email-notification-when-items-are-returned.json
@@ -1,0 +1,16 @@
+{
+  "docs": "Use this task to get an email alert with a list of the returned items whenever a return is marked as closed.\n\nNote: this event will not occur when returns or exchanges are made via a POS terminal.",
+  "halt_action_run_sequence_on_error": false,
+  "name": "Send email notification when items are returned",
+  "online_store_javascript": null,
+  "options": {
+    "email_recipients__array_required": null
+  },
+  "order_status_javascript": null,
+  "perform_action_runs_in_sequence": false,
+  "preview_event_definitions": [],
+  "script": "{% assign email_recipients = options.email_recipients__array_required %}\n\n{% if event.topic == \"shopify/returns/close\" %}\n  {% capture query %}\n    query {\n      return(id: {{ return.admin_graphql_api_id | json }}) {\n        name\n        returnLineItems(first: 100) {\n          nodes {\n            quantity\n            returnReason\n            fulfillmentLineItem {\n              lineItem {\n                name\n                sku\n              }\n            }\n          }\n        }\n      }\n    }  \n  {% endcapture %}\n  \n  {% assign result = query | shopify %}\n  \n  {% if event.preview %}\n    {% capture result_json %}\n      {\n        \"data\": {\n          \"return\": {\n            \"name\": \"#PREVIEW-R1\",\n            \"returnLineItems\": {\n              \"nodes\": [\n                {\n                  \"quantity\": 1,\n                  \"returnReason\": \"STYLE\",\n                  \"fulfillmentLineItem\": {\n                    \"lineItem\": {\n                      \"name\": \"Widget - Chartreuse\",\n                      \"sku\": \"WDGT-CHRTRS\"\n                    }\n                  }\n                }\n              ]\n            }\n          }\n        }\n      }\n    {% endcapture %}\n  \n    {% assign result = result_json | parse_json %}\n  {% endif %}\n  \n  {% capture email_subject %}ALERT: New return {{ result.data.return.name }}{% endcapture %}\n\n  {% capture email_body -%}\n    Returned items\n    ==============\n    {% for return_line_item in result.data.return.returnLineItems.nodes %}\n      Title: <strong>{{ return_line_item.fulfillmentLineItem.lineItem.name }}</strong>\n      SKU: <strong>{{ return_line_item.fulfillmentLineItem.lineItem.sku }}</strong>\n      Quantity: <strong>{{ return_line_item.quantity }}</strong>\n      Reason: <strong>{{ return_line_item.returnReason }}</strong>\n    {% endfor %}\n  {% endcapture %}\n\n  {% action \"email\" %}\n    {\n      \"to\": {{ email_recipients | json }},\n      \"subject\": {{ email_subject | json }},\n      \"body\": {{ email_body | newline_to_br | json }},\n      \"reply_to\": {{ shop.customer_email | json }},\n      \"from_display_name\": {{ shop.name | json }}\n    }\n  {% endaction %}\n{% endif %}",
+  "subscriptions": ["shopify/returns/close"],
+  "subscriptions_template": "shopify/returns/close",
+  "tags": ["Alert", "Email", "Returns"]
+}


### PR DESCRIPTION
New task by community request

Slack thread - https://usemechanic.slack.com/archives/C039BQGF8LV/p1689365260815649

Note: this task has not been tested with POS returns/exchanges, but per the API docs those actions should not be firing the returns/close event.