### PR TITLE
Revert "chore(deps): update actions/checkout action to v4"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+    - uses: actions/checkout@v3
     - name: Install node and npm
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
Reverts lightward/mechanic-tasks#276

This update requires node v20, which we have not yet updated to