### PR TITLE
Revert "chore(deps): update actions/setup-node action to v4"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install node and npm
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v3
       with:
         node-version: 18
         check-latest: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "engines": {
         "node": ">=18 <19",
-        "npm": ">=9 <10"
+        "npm": ">=9 <11"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://tasks.mechanic.dev/",
   "engines": {
     "node": ">=18 <19",
-    "npm": ">=9 <10"
+    "npm": ">=9 <11"
   },
   "dependencies": {
     "@shopify/prettier-config": "1.1.2",


### PR DESCRIPTION
Reverts lightward/mechanic-tasks#292

This update pushed npm to v10 causing build errors due to package.json config; reverting until repo upgraded to use node v20 / npm v10 