### PR TITLE
upgrade husky manually with config file changes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npm test && npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "ajv": "8.12.0",
         "dir-compare": "4.2.0",
         "glob": "10.3.10",
-        "husky": "8.0.3",
+        "husky": "^9.0.7",
         "lint-staged": "15.2.0",
         "prettier": "3.2.4",
         "sort-json": "2.0.1"
@@ -417,14 +417,14 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.7.tgz",
+      "integrity": "sha512-vWdusw+y12DUEeoZqW1kplOFqk3tedGV8qlga8/SF6a3lOiWLqGZZQvfWvY0fQYdfiRi/u1DFNpudTSV9l1aCg==",
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
@@ -1501,9 +1501,9 @@
       "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="
     },
     "husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.7.tgz",
+      "integrity": "sha512-vWdusw+y12DUEeoZqW1kplOFqk3tedGV8qlga8/SF6a3lOiWLqGZZQvfWvY0fQYdfiRi/u1DFNpudTSV9l1aCg=="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
     "ajv": "8.12.0",
     "dir-compare": "4.2.0",
     "glob": "10.3.10",
-    "husky": "8.0.3",
+    "husky": "^9.0.7",
+    "lint-staged": "15.2.0",
     "prettier": "3.2.4",
-    "sort-json": "2.0.1",
-    "lint-staged": "15.2.0"
+    "sort-json": "2.0.1"
   },
   "scripts": {
     "test": "node ./lib/test.js",
     "build": "node ./lib/build.js",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "lint-staged": {
     "*.{js,json}": [


### PR DESCRIPTION
Renovate would only update the package, but there are a couple of config changes needed as well, so pushing this update manually.