### PR TITLE
Add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 yarn.lock
 .DS_Store
+CLAUDE.md


### PR DESCRIPTION
This PR adds CLAUDE.md to the .gitignore file.

CLAUDE.md is a local development file used by Claude Code for repository-specific guidance and should not be committed to version control.