### PR TITLE
Add /test-local/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 yarn.lock
 .DS_Store
 CLAUDE.md
+/test-local/


### PR DESCRIPTION
## Summary
- Adds `/test-local/` directory to .gitignore
- This directory is used for local development scripts and testing

## Why
The `/test-local/` directory contains development tools and scripts that are specific to local development environments. These files should not be tracked in version control as they are developer-specific.