### PR TITLE
Untag orders when closed/archived

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -356,6 +356,7 @@ This directory is built automatically. Each task's documentation is generated fr
 * [Unpublish products that fall below a rolling sales threshold](./unpublish-products-that-fall-below-a-rolling-sales-threshold)
 * [Unpublish products that have been out of stock for x days](./unpublish-products-that-have-been-out-of-stock-for-x-days)
 * [Unpublish products when tagged](./unpublish-products-when-tagged)
+* [Untag orders when closed/archived](./untag-orders-when-closed-archived)
 * [Untag orders when paid](./untag-orders-when-paid)
 * [Update empty customer data from addresses](./update-empty-customer-data-from-addresses)
 * [Update product description when out of stock](./update-product-description-when-out-of-stock)
@@ -1298,6 +1299,7 @@ This directory is built automatically. Each task's documentation is generated fr
 * [Tag orders in bulk by order name](./tag-orders-in-bulk-by-order-name)
 * [Tag orders that have at least x of a certain product](./tag-orders-that-have-at-least-x-of-a-certain-product)
 * [Trigger order emails with a tag](./trigger-order-emails-with-a-tag)
+* [Untag orders when closed/archived](./untag-orders-when-closed-archived)
 * [Untag orders when paid](./untag-orders-when-paid)
 
 ### Out of Stock
@@ -1801,6 +1803,7 @@ This directory is built automatically. Each task's documentation is generated fr
 * [Remove a product tag when another tag is added](./remove-a-product-tag-when-another-tag-is-added)
 * [Remove an order tag when another tag is added](./remove-a-order-tag-when-another-tag-is-added)
 * [Remove matched tags from all products](./remove-specified-tags-from-all-products)
+* [Untag orders when closed/archived](./untag-orders-when-closed-archived)
 * [Untag orders when paid](./untag-orders-when-paid)
 
 ### Variants

--- a/docs/untag-orders-when-closed-archived/README.md
+++ b/docs/untag-orders-when-closed-archived/README.md
@@ -1,0 +1,43 @@
+# Untag orders when closed/archived
+
+Tags: Orders, Untag
+
+This task automatically removes specific order tag(s) when orders are closed/archived.
+
+* View in the task library: [tasks.mechanic.dev/untag-orders-when-closed-archived](https://tasks.mechanic.dev/untag-orders-when-closed-archived)
+* Task JSON, for direct import: [task.json](../../tasks/untag-orders-when-closed-archived.json)
+* Preview task code: [script.liquid](./script.liquid)
+
+## Default options
+
+```json
+{
+  "order_tags_to_remove__array": []
+}
+```
+
+[Learn about task options in Mechanic](https://learn.mechanic.dev/core/tasks/options)
+
+## Subscriptions
+
+```liquid
+shopify/orders/updated
+```
+
+[Learn about event subscriptions in Mechanic](https://learn.mechanic.dev/core/tasks/subscriptions)
+
+## Documentation
+
+This task automatically removes specific order tag(s) when orders are closed/archived.
+
+## Installing this task
+
+Find this task [in the library at tasks.mechanic.dev](https://tasks.mechanic.dev/untag-orders-when-closed-archived), and use the "Try this task" button. Or, import [this task's JSON export](../../tasks/untag-orders-when-closed-archived.json) – see [Importing and exporting tasks](https://learn.mechanic.dev/core/tasks/import-and-export) to learn how imports work.
+
+## Contributions
+
+Found a bug? Got an improvement to add? Start here: [../../CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Task requests
+
+Submit your [task requests](https://mechanic.canny.io/task-requests) for consideration by the Mechanic community, and they may be chosen for development and inclusion in the [task library](https://tasks.mechanic.dev/)!

--- a/docs/untag-orders-when-closed-archived/script.liquid
+++ b/docs/untag-orders-when-closed-archived/script.liquid
@@ -1,0 +1,26 @@
+{% if event.preview %}
+  {% capture order_json %}
+    {
+      "admin_graphql_api_id": "gid://shopify/Order/12345",
+      "closed_at" : "2025-01-01T00:00:00+00:00"
+    }
+  {% endcapture %}
+
+  {% assign order = order_json | parse_json %}
+{% endif %}
+
+{% if order.closed_at %}
+  {% action "shopify" %}
+    mutation {
+      tagsRemove(
+        id: {{ order.admin_graphql_api_id | json }}
+        tags: {{ options.order_tags_to_remove__array | json }}
+      ) {
+        userErrors {
+          field
+          message
+        }
+      }
+    }
+  {% endaction %}
+{% endif %}

--- a/tasks/untag-orders-when-closed-archived.json
+++ b/tasks/untag-orders-when-closed-archived.json
@@ -1,0 +1,20 @@
+{
+  "docs": "This task automatically removes specific order tag(s) when orders are closed/archived.",
+  "halt_action_run_sequence_on_error": false,
+  "name": "Untag orders when closed/archived",
+  "online_store_javascript": null,
+  "options": {
+    "order_tags_to_remove__array": []
+  },
+  "perform_action_runs_in_sequence": false,
+  "preview_event_definitions": [],
+  "script": "{% if event.preview %}\n  {% capture order_json %}\n    {\n      \"admin_graphql_api_id\": \"gid://shopify/Order/12345\",\n      \"closed_at\" : \"2025-01-01T00:00:00+00:00\"\n    }\n  {% endcapture %}\n\n  {% assign order = order_json | parse_json %}\n{% endif %}\n\n{% if order.closed_at %}\n  {% action \"shopify\" %}\n    mutation {\n      tagsRemove(\n        id: {{ order.admin_graphql_api_id | json }}\n        tags: {{ options.order_tags_to_remove__array | json }}\n      ) {\n        userErrors {\n          field\n          message\n        }\n      }\n    }\n  {% endaction %}\n{% endif %}\n",
+  "subscriptions": [
+    "shopify/orders/updated"
+  ],
+  "subscriptions_template": "shopify/orders/updated",
+  "tags": [
+    "Orders",
+    "Untag"
+  ]
+}


### PR DESCRIPTION
> This task automatically removes specific order tag(s) when orders are closed/archived.

[Canny Request](https://mechanic.canny.io/task-requests/p/untag-orders-when-closedarchvied) Another low-hanging fruit. The code is almost identical to [Untag orders when paid](https://tasks.mechanic.dev/untag-orders-when-paid).

I'm wondering if this would make sense to fold into the first task rather than having a separate task? It would have a radio select to determine which event to act on (paid, archived, fulfilled?...). I don't know how task migration works though, so it might not be possible to add those options to a task that's already installed in stores.